### PR TITLE
Add DoNotLock policy

### DIFF
--- a/SystemRuntime.UnitTests/SystemRuntime.UnitTests.csproj
+++ b/SystemRuntime.UnitTests/SystemRuntime.UnitTests.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>PubComp.Caching.SystemRuntime.UnitTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
   </ItemGroup>

--- a/SystemRuntime/InMemoryPolicy.cs
+++ b/SystemRuntime/InMemoryPolicy.cs
@@ -31,5 +31,11 @@ namespace PubComp.Caching.SystemRuntime
         /// <remarks>Default value is a time-duration value that is set to zero,
         /// which indicates that a cache entry has no sliding expiration time</remarks>
         public TimeSpan? SlidingExpiration { get; set; }
+
+        /// <summary>
+        /// Whether or not to lock on cache misses before calling underlying getter.
+        /// </summary>
+        /// <remarks>Default value is false, which indicates lock will be used.</remarks>
+        public bool DoNotLock { get; set; }
     }
 }

--- a/SystemRuntime/ObjectCache.cs
+++ b/SystemRuntime/ObjectCache.cs
@@ -119,7 +119,8 @@ namespace PubComp.Caching.SystemRuntime
             if (TryGetInner(key, out value))
                 return value;
 
-            sync.Wait();
+            if (!policy.DoNotLock) sync.Wait();
+
             try
             {
                 if (TryGetInner(key, out value))
@@ -130,7 +131,7 @@ namespace PubComp.Caching.SystemRuntime
             }
             finally
             {
-                sync.Release();
+                if (!policy.DoNotLock) sync.Release();
             }
 
             return value;
@@ -141,7 +142,7 @@ namespace PubComp.Caching.SystemRuntime
             if (TryGetInner(key, out TValue value))
                 return value;
 
-            await sync.WaitAsync().ConfigureAwait(false); //This will deadlock if reentered recursively -- should not happen
+            if (!policy.DoNotLock) await sync.WaitAsync().ConfigureAwait(false); //This will deadlock if reentered recursively -- should not happen
             try
             {
                 if (TryGetInner(key, out value))
@@ -152,7 +153,7 @@ namespace PubComp.Caching.SystemRuntime
             }
             finally
             {
-                sync.Release();
+                if (!policy.DoNotLock) sync.Release();
             }
 
             return value;

--- a/SystemRuntime/SystemRuntime.csproj
+++ b/SystemRuntime/SystemRuntime.csproj
@@ -4,9 +4,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>PubComp.Caching.SystemRuntime</AssemblyName>
     <RootNamespace>PubComp.Caching.SystemRuntime</RootNamespace>
-    <Version>4.1.1</Version>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
-    <FileVersion>4.1.1.0</FileVersion>
+    <Version>4.2.0</Version>
+    <AssemblyVersion>4.2.0.0</AssemblyVersion>
+    <FileVersion>4.2.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
   <PackageReference Include="System.Runtime.Caching" Version="4.5.0" />


### PR DESCRIPTION
The change from lock(obj) to SemaphoreSlim.Wait() changed the protection against deadlocks for reentrants. This adds a policy that can avoid the lock.