### PR TITLE
Add a different configuration source to load from (IConfiguration)

### DIFF
--- a/AopCaching.UnitTests/AopCacheTests.cs
+++ b/AopCaching.UnitTests/AopCacheTests.cs
@@ -18,23 +18,16 @@ namespace PubComp.Caching.AopCaching.UnitTests
         [ClassInitialize]
         public static void ClassInitialize(TestContext testContext)
         {
+            // The following caches are set in the Assembly Initialize
+
             const string cache1Name = "PubComp.Caching.AopCaching.UnitTests.Mocks.Service*";
             cache1 = CacheManager.GetCache(cache1Name) as MockCache;
-            if (cache1 == null || cache1.Name != cache1Name)
-                cache1 = new MockCache(cache1Name);
-            CacheManager.SetCache(cache1.Name, cache1);
 
             const string cache2Name = "localCache";
             cache2 = CacheManager.GetCache(cache2Name) as MockCache;
-            if (cache2 == null || cache2.Name != cache2Name)
-                cache2 = new MockCache(cache2Name);
-            CacheManager.SetCache(cache2.Name, cache2);
 
             const string cache3Name = "PubComp.Caching.AopCaching.UnitTests.Mocks.Generic*";
             cache3 = CacheManager.GetCache(cache3Name) as MockCache;
-            if (cache3 == null || cache3.Name != cache3Name)
-                cache3 = new MockCache(cache3Name);
-            CacheManager.SetCache(cache3.Name, cache3);
         }
 
         [TestInitialize]

--- a/AopCaching.UnitTests/AopMultiCacheTests.cs
+++ b/AopCaching.UnitTests/AopMultiCacheTests.cs
@@ -16,11 +16,10 @@ namespace PubComp.Caching.AopCaching.UnitTests
         [ClassInitialize]
         public static void ClassInitialize(TestContext testContext)
         {
+            // The following caches are set in the Assembly Initialize
+
             const string cache1Name = "PubComp.Caching.AopCaching.UnitTests.Mocks.*";
             cache1 = CacheManager.GetCache(cache1Name) as MockCache;
-            if (cache1 == null || cache1.Name != cache1Name)
-                cache1 = new MockCache(cache1Name);
-            CacheManager.SetCache(cache1.Name, cache1);
         }
 
         [TestInitialize]

--- a/AopCaching.UnitTests/AopTestsAssemblyInitializer.cs
+++ b/AopCaching.UnitTests/AopTestsAssemblyInitializer.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PubComp.Caching.AopCaching.UnitTests.Mocks;
+using PubComp.Caching.Core;
+using PubComp.Caching.Core.Config.Loaders;
+
+namespace PubComp.Caching.AopCaching.UnitTests
+{
+    [TestClass]
+    public class AopTestsAssemblyInitializer
+    {
+        [AssemblyInitialize]
+        public static void AssemblyInit(TestContext context)
+        {
+            // 2 cache definitions are from the in-memory configuration and 2 are set programmatically.
+            // The reason MicrosoftExtensionsCacheConfigLoader is used instead of a mock is to verify
+            // the "name*" convention is working properly with the RL implementation of the loader
+
+            var cb = new ConfigurationBuilder()
+                .AddInMemoryCollection(CacheConfiguration())
+                .Build();
+
+            CacheManager.Settings = new CacheManagerSettings
+            {
+                ConfigLoader = new MicrosoftExtensionsCacheConfigLoader(cb)
+            };
+            CacheManager.InitializeFromConfig();
+
+            const string cache1Name = "PubComp.Caching.AopCaching.UnitTests.Mocks.Service*";
+            var cache1 = new MockCache(cache1Name);
+            CacheManager.SetCache(cache1.Name, cache1);
+
+            const string cache2Name = "localCache";
+            var cache2 = new MockCache(cache2Name);
+            CacheManager.SetCache(cache2.Name, cache2);
+
+            //const string cache3Name = "PubComp.Caching.AopCaching.UnitTests.Mocks.Generic*";
+            //var cache3 = new MockCache(cache3Name);
+            //CacheManager.SetCache(cache3.Name, cache3);
+
+            //const string cacheMulti1Name = "PubComp.Caching.AopCaching.UnitTests.Mocks.*";
+            //var cacheMulti1 = new MockCache(cacheMulti1Name);
+            //CacheManager.SetCache(cacheMulti1.Name, cacheMulti1);
+        }
+
+        private static Dictionary<string, string> CacheConfiguration()
+        {
+            var result = new Dictionary<string, string>
+            {
+                {"PubComp:CacheConfig:PubComp.Caching.AopCaching.UnitTests.Mocks.Generic*:Assembly", "PubComp.Caching.AopCaching.UnitTests"},
+                {"PubComp:CacheConfig:PubComp.Caching.AopCaching.UnitTests.Mocks.Generic*:Type", "PubComp.Caching.AopCaching.UnitTests.Mocks.MockCache"},
+                {"PubComp:CacheConfig:PubComp.Caching.AopCaching.UnitTests.Mocks.*:Assembly", "PubComp.Caching.AopCaching.UnitTests"},
+                {"PubComp:CacheConfig:PubComp.Caching.AopCaching.UnitTests.Mocks.*:Type", "PubComp.Caching.AopCaching.UnitTests.Mocks.MockCache"},
+            };
+            
+            return result;
+        }
+    }
+}

--- a/AopCaching.UnitTests/Mocks/MockCacheConfig.cs
+++ b/AopCaching.UnitTests/Mocks/MockCacheConfig.cs
@@ -1,0 +1,13 @@
+﻿using PubComp.Caching.Core;
+using PubComp.Caching.Core.Config;
+
+namespace PubComp.Caching.AopCaching.UnitTests.Mocks
+{
+    public class MockCacheConfig : CacheConfig
+    {
+        public override ICache CreateCache()
+        {
+            return new MockCache(this.Name);
+        }
+    }
+}

--- a/Core.UnitTests/App.config
+++ b/Core.UnitTests/App.config
@@ -56,4 +56,5 @@
     </rules>
   </nlog>
   
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup>
+</configuration>

--- a/Core.UnitTests/CacheConfigFileTests.cs
+++ b/Core.UnitTests/CacheConfigFileTests.cs
@@ -17,7 +17,8 @@ namespace PubComp.Caching.Core.UnitTests
         public void TestInitialize()
         {
             CacheManager.CacheManagerLogic = null;
-            CacheManager.ConfigLoader = new SystemConfigurationManagerCacheConfigLoader();
+            CacheManager.Settings = new CacheManagerSettings
+                {ConfigLoader = new SystemConfigurationManagerCacheConfigLoader(), ShouldRegisterAllCaches = false};
             CacheManager.RemoveAllCaches();
         }
 

--- a/Core.UnitTests/CacheConfigFileTests.cs
+++ b/Core.UnitTests/CacheConfigFileTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PubComp.Caching.Core.Config;
+using PubComp.Caching.Core.Config.Loaders;
 using PubComp.Caching.Core.UnitTests.Mocks;
 
 namespace PubComp.Caching.Core.UnitTests
@@ -15,6 +16,8 @@ namespace PubComp.Caching.Core.UnitTests
         [TestInitialize]
         public void TestInitialize()
         {
+            CacheManager.CacheManagerLogic = null;
+            CacheManager.ConfigLoader = new SystemConfigurationManagerCacheConfigLoader();
             CacheManager.RemoveAllCaches();
         }
 

--- a/Core.UnitTests/CacheConfigFileTests.cs
+++ b/Core.UnitTests/CacheConfigFileTests.cs
@@ -13,13 +13,17 @@ namespace PubComp.Caching.Core.UnitTests
     [TestClass]
     public class CacheConfigFileTests
     {
+        private CacheManagerLogic _cacheManagerLogic;
+
         [TestInitialize]
         public void TestInitialize()
         {
             CacheManager.CacheManagerLogic = null;
             CacheManager.Settings = new CacheManagerSettings
                 {ConfigLoader = new SystemConfigurationManagerCacheConfigLoader(), ShouldRegisterAllCaches = false};
-            CacheManager.RemoveAllCaches();
+            CacheManager.InitializeFromConfig();
+            _cacheManagerLogic = CacheManager.CacheManagerLogic;
+
         }
 
         [TestMethod]
@@ -100,40 +104,38 @@ namespace PubComp.Caching.Core.UnitTests
         [TestMethod]
         public void TestCreateCachesFromAppConfig()
         {
-            CacheManager.InitializeFromConfig();
-
-            var cache1 = CacheManager.GetCache("cacheFromConfig1");
+            var cache1 = _cacheManagerLogic.GetCache("cacheFromConfig1");
             Assert.IsNotNull(cache1);
             Assert.IsInstanceOfType(cache1, typeof(NoCache));
 
-            var cache2 = CacheManager.GetCache("cacheFromConfig2");
+            var cache2 = _cacheManagerLogic.GetCache("cacheFromConfig2");
             Assert.IsNotNull(cache2);
             Assert.IsInstanceOfType(cache2, typeof(MockNoCache));
             Assert.IsNotNull(((MockNoCache)cache2).Policy);
             Assert.IsNotNull(((MockNoCache)cache2).Policy.SlidingExpiration);
             Assert.AreEqual(new TimeSpan(0, 15, 0), ((MockNoCache)cache2).Policy.SlidingExpiration);
 
-            var cache3 = CacheManager.GetCache("cacheFromConfig3");
+            var cache3 = _cacheManagerLogic.GetCache("cacheFromConfig3");
             Assert.IsNull(cache3);
 
-            var cache4 = CacheManager.GetCache("cacheFromConfig4");
+            var cache4 = _cacheManagerLogic.GetCache("cacheFromConfig4");
             Assert.IsNull(cache4);
         }
 
         [TestMethod]
         public void TestReadConnectionStringsFromConfig()
         {
-            var connectionString0 = CacheManager.GetConnectionString("localRedisUrl");
+            var connectionString0 = _cacheManagerLogic.GetConnectionString("localRedisUrl");
             Assert.IsInstanceOfType(connectionString0, typeof(PlainConnectionString));
             Assert.AreEqual("localRedisUrl", connectionString0.Name);
             Assert.AreEqual("127.0.0.1:6379,serviceName=mymaster", connectionString0.ConnectionString);
 
-            var connectionString1 = CacheManager.GetConnectionString("localRedisUrlEnc");
+            var connectionString1 = _cacheManagerLogic.GetConnectionString("localRedisUrlEnc");
             Assert.IsInstanceOfType(connectionString1, typeof(UrlEncConnectionString));
             Assert.AreEqual("localRedisUrlEnc", connectionString1.Name);
             Assert.AreEqual("127.0.0.1:6379,serviceName=mymaster", connectionString1.ConnectionString);
 
-            var connectionString2 = CacheManager.GetConnectionString("localRedisB64Enc");
+            var connectionString2 = _cacheManagerLogic.GetConnectionString("localRedisB64Enc");
             Assert.IsInstanceOfType(connectionString2, typeof(B64EncConnectionString));
             Assert.AreEqual("localRedisB64Enc", connectionString2.Name);
             Assert.AreEqual("127.0.0.1:6379,serviceName=mymaster,allowAdmin=true", connectionString2.ConnectionString);
@@ -142,7 +144,7 @@ namespace PubComp.Caching.Core.UnitTests
         [TestMethod]
         public void TestReadNotifierFromConfig()
         {
-            var notifier = CacheManager.GetNotifier("noNotifier");
+            var notifier = _cacheManagerLogic.GetNotifier("noNotifier");
             Assert.IsInstanceOfType(notifier, typeof(NoNotifier));
             Assert.AreEqual("noNotifier", notifier.Name);
             Assert.AreEqual("127.0.0.1:6379,serviceName=mymaster,allowAdmin=true", GetFieldValue(notifier));

--- a/Core.UnitTests/CacheConfigTests.cs
+++ b/Core.UnitTests/CacheConfigTests.cs
@@ -13,7 +13,7 @@ namespace PubComp.Caching.Core.UnitTests
         [TestInitialize]
         public void TestInitialize()
         {
-            CacheManager.ConfigLoader = null;
+            CacheManager.Settings = null;
             CacheManager.CacheManagerLogic = null;
             CacheManager.RemoveAllCaches();
         }

--- a/Core.UnitTests/CacheConfigTests.cs
+++ b/Core.UnitTests/CacheConfigTests.cs
@@ -15,7 +15,6 @@ namespace PubComp.Caching.Core.UnitTests
         {
             CacheManager.Settings = null;
             CacheManager.CacheManagerLogic = null;
-            CacheManager.RemoveAllCaches();
         }
 
         [TestMethod]

--- a/Core.UnitTests/CacheConfigTests.cs
+++ b/Core.UnitTests/CacheConfigTests.cs
@@ -13,6 +13,8 @@ namespace PubComp.Caching.Core.UnitTests
         [TestInitialize]
         public void TestInitialize()
         {
+            CacheManager.ConfigLoader = null;
+            CacheManager.CacheManagerLogic = null;
             CacheManager.RemoveAllCaches();
         }
 

--- a/Core.UnitTests/CacheControllerUtilTests.cs
+++ b/Core.UnitTests/CacheControllerUtilTests.cs
@@ -17,7 +17,7 @@ namespace PubComp.Caching.Core.UnitTests
         [TestInitialize]
         public void TestInitialize()
         {
-            CacheManager.ConfigLoader = null;
+            CacheManager.Settings = null;
             CacheManager.CacheManagerLogic = null;
             CacheManager.RemoveAllCaches();
 

--- a/Core.UnitTests/CacheControllerUtilTests.cs
+++ b/Core.UnitTests/CacheControllerUtilTests.cs
@@ -17,8 +17,10 @@ namespace PubComp.Caching.Core.UnitTests
         [TestInitialize]
         public void TestInitialize()
         {
+            CacheManager.ConfigLoader = null;
+            CacheManager.CacheManagerLogic = null;
             CacheManager.RemoveAllCaches();
-            
+
             CacheManager.SetCache("cache*", new NoCache());
 
             cache1 = new Mocks.MockMemCache("cache1");

--- a/Core.UnitTests/CacheControllerUtilTests.cs
+++ b/Core.UnitTests/CacheControllerUtilTests.cs
@@ -19,7 +19,6 @@ namespace PubComp.Caching.Core.UnitTests
         {
             CacheManager.Settings = null;
             CacheManager.CacheManagerLogic = null;
-            CacheManager.RemoveAllCaches();
 
             CacheManager.SetCache("cache*", new NoCache());
 

--- a/Core.UnitTests/CacheExplicitJsonConfigFileTests.cs
+++ b/Core.UnitTests/CacheExplicitJsonConfigFileTests.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Linq;
-using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using PubComp.Caching.Core.Config;
 using PubComp.Caching.Core.Config.Loaders;
 using PubComp.Caching.Core.UnitTests.Mocks;
 
@@ -23,6 +20,8 @@ namespace PubComp.Caching.Core.UnitTests
 
             var configuration = new ConfigurationBuilder()
                 .AddJsonFile("unittests_pubcompcachesettings.json", false, false)
+                .AddJsonFile("unittests_pubcompcachesettings_override1.json", false, false)
+                .AddJsonFile("unittests_pubcompcachesettings_override2.json", false, false)
                 .Build();
             // The json loading is not part of the test, it's just a convenient helper.
 
@@ -79,7 +78,13 @@ namespace PubComp.Caching.Core.UnitTests
             Assert.IsNotNull(connectionString1);
             Assert.IsInstanceOfType(connectionString1, typeof(B64EncConnectionString));
             Assert.AreEqual("127.0.0.1:6379,serviceName=mymaster,allowAdmin=true",
-                ((B64EncConnectionString) connectionString1).ConnectionString);
+                ((B64EncConnectionString)connectionString1).ConnectionString);
+
+            var connectionString2 = CacheManager.GetConnectionString("localRedisUrl");
+            Assert.IsNotNull(connectionString2);
+            Assert.IsInstanceOfType(connectionString2, typeof(PlainConnectionString));
+            Assert.AreEqual("127.0.0.1:6379,serviceName=mymaster",
+                ((PlainConnectionString)connectionString2).ConnectionString);
         }
 
         [TestMethod]
@@ -101,12 +106,10 @@ namespace PubComp.Caching.Core.UnitTests
             var configuration = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>
                     {
-                        { "PubComp:CacheConfig:0:name", "nameTypeNotFound1" },
-                        { "PubComp:CacheConfig:0:assembly", "PubComp.Caching.Core" },
-                        { "PubComp:CacheConfig:0:type", "typeNotFound" },
-                        { "PubComp:CacheConfig:1:name", "nameAssemblyNotFound1" },
-                        { "PubComp:CacheConfig:1:assembly", "PubComp.Caching.Core.AssemblyNotFound" },
-                        { "PubComp:CacheConfig:1:type", "typeNotFound" },
+                        { "PubComp:CacheConfig:nameTypeNotFound1:assembly", "PubComp.Caching.Core" },
+                        { "PubComp:CacheConfig:nameTypeNotFound1:type", "typeNotFound" },
+                        { "PubComp:CacheConfig:nameAssemblyNotFound1:assembly", "PubComp.Caching.Core.AssemblyNotFound" },
+                        { "PubComp:CacheConfig:nameAssemblyNotFound1:type", "typeNotFound" },
                     }
                 )
                 .Build();

--- a/Core.UnitTests/CacheExplicitJsonConfigFileTests.cs
+++ b/Core.UnitTests/CacheExplicitJsonConfigFileTests.cs
@@ -98,6 +98,7 @@ namespace PubComp.Caching.Core.UnitTests
             Assert.IsTrue(registeredCacheNames.All(rcn => cacheNames.Contains(rcn)));
         }
 
+        [ExpectedException(typeof(CacheConfigLoadErrorsException))]
         [TestMethod]
         public void TestMECConfigLoader_AssemblyError()
         {

--- a/Core.UnitTests/CacheExplicitJsonConfigFileTests.cs
+++ b/Core.UnitTests/CacheExplicitJsonConfigFileTests.cs
@@ -25,8 +25,12 @@ namespace PubComp.Caching.Core.UnitTests
                 .Build();
             // The json loading is not part of the test, it's just a convenient helper.
 
-            CacheManager.Settings = new CacheManagerSettings
-                { ConfigLoader = new MicrosoftExtensionsCacheConfigLoader(configuration), ShouldRegisterAllCaches = true };
+            CacheManager.Settings =
+                new CacheManagerSettings
+                {
+                    ConfigLoader = new MicrosoftExtensionsCacheConfigLoader(configuration),
+                    ShouldRegisterAllCaches = true
+                };
         }
 
         [TestMethod]

--- a/Core.UnitTests/CacheImplicitAppConfigFileTests.cs
+++ b/Core.UnitTests/CacheImplicitAppConfigFileTests.cs
@@ -16,17 +16,22 @@ namespace PubComp.Caching.Core.UnitTests
         [TestInitialize]
         public void TestInitialize()
         {
+            new CacheControllerUtil().ClearRegisteredCacheNames();
+
             // The test can't be completely implicit as the CacheManager is a singleton
             // this is carried across all unit-tests.
             CacheManager.CacheManagerLogic = null;
-            CacheManager.ConfigLoader = new SystemConfigurationManagerCacheConfigLoader();
+            CacheManager.Settings = new CacheManagerSettings
+                { ConfigLoader = new SystemConfigurationManagerCacheConfigLoader(), ShouldRegisterAllCaches = false };
         }
 
         [TestMethod]
         public void TestSCMConfigLoader()
         {
             Assert.IsNotNull(CacheManager.CacheManagerLogic);
-            Assert.IsInstanceOfType(CacheManager.CacheManagerLogic.ConfigLoader, typeof(SystemConfigurationManagerCacheConfigLoader));
+            Assert.IsNotNull(CacheManager.CacheManagerLogic.Settings);
+            Assert.IsInstanceOfType(CacheManager.CacheManagerLogic.Settings.ConfigLoader, typeof(SystemConfigurationManagerCacheConfigLoader));
+            Assert.AreEqual(false, CacheManager.CacheManagerLogic.Settings.ShouldRegisterAllCaches);
         }
 
         [TestMethod]
@@ -70,6 +75,15 @@ namespace PubComp.Caching.Core.UnitTests
             Assert.IsInstanceOfType(connectionString1, typeof(B64EncConnectionString));
             Assert.AreEqual("127.0.0.1:6379,serviceName=mymaster,allowAdmin=true",
                 ((B64EncConnectionString)connectionString1).ConnectionString);
+        }
+
+        [TestMethod]
+        public void TestNotRegisteredCacheNames()
+        {
+            var ccu = new CacheControllerUtil();
+            var registeredCacheNames = ccu.GetRegisteredCacheNames().ToList();
+
+            Assert.AreEqual(0, registeredCacheNames.Count);
         }
     }
 }

--- a/Core.UnitTests/CacheImplicitAppConfigFileTests.cs
+++ b/Core.UnitTests/CacheImplicitAppConfigFileTests.cs
@@ -17,8 +17,12 @@ namespace PubComp.Caching.Core.UnitTests
             // The test can't be completely implicit as the CacheManager is a singleton
             // this is carried across all unit-tests.
             CacheManager.CacheManagerLogic = null;
-            CacheManager.Settings = new CacheManagerSettings
-                { ConfigLoader = new SystemConfigurationManagerCacheConfigLoader(), ShouldRegisterAllCaches = false };
+            CacheManager.Settings =
+                new CacheManagerSettings
+                {
+                    ConfigLoader = new SystemConfigurationManagerCacheConfigLoader(),
+                    ShouldRegisterAllCaches = false
+                };
         }
 
         [TestMethod]

--- a/Core.UnitTests/CacheImplicitAppConfigFileTests.cs
+++ b/Core.UnitTests/CacheImplicitAppConfigFileTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PubComp.Caching.Core.Config;
+using PubComp.Caching.Core.UnitTests.Mocks;
+
+namespace PubComp.Caching.Core.UnitTests
+{
+    [TestClass]
+    public class CacheImplicitAppConfigFileTests
+    {
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            CacheManager.CacheManagerLogic = null;
+        }
+
+        [TestMethod]
+        public void TestReadAppConfig()
+        {
+            var cacheNames = CacheManager.GetCacheNames();
+            var connectionStringNames = CacheManager.GetConnectionStringNames();
+            var notifierNames = CacheManager.GetNotifierNames();
+
+            Assert.AreEqual(2, cacheNames.Count());
+            Assert.AreEqual(3, connectionStringNames.Count());
+            Assert.AreEqual(1, notifierNames.Count());
+        }
+
+        [TestMethod]
+        public void TestCreateCachesFromAppConfig()
+        {
+            var cache1 = CacheManager.GetCache("cacheFromConfig1");
+            Assert.IsNotNull(cache1);
+            Assert.IsInstanceOfType(cache1, typeof(NoCache));
+
+            var cache2 = CacheManager.GetCache("cacheFromConfig2");
+            Assert.IsNotNull(cache2);
+            Assert.IsInstanceOfType(cache2, typeof(MockNoCache));
+            Assert.IsNotNull(((MockNoCache)cache2).Policy);
+            Assert.IsNotNull(((MockNoCache)cache2).Policy.SlidingExpiration);
+            Assert.AreEqual(new TimeSpan(0, 15, 0), ((MockNoCache)cache2).Policy.SlidingExpiration);
+
+            var cache3 = CacheManager.GetCache("cacheFromConfig3");
+            Assert.IsNull(cache3);
+
+            var cache4 = CacheManager.GetCache("cacheFromConfig4");
+            Assert.IsNull(cache4);
+        }
+    }
+}

--- a/Core.UnitTests/CacheImplicitAppConfigFileTests.cs
+++ b/Core.UnitTests/CacheImplicitAppConfigFileTests.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
 using System.Linq;
-using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using PubComp.Caching.Core.Config;
 using PubComp.Caching.Core.Config.Loaders;
 using PubComp.Caching.Core.UnitTests.Mocks;
 

--- a/Core.UnitTests/CacheManagerTests.cs
+++ b/Core.UnitTests/CacheManagerTests.cs
@@ -9,7 +9,7 @@ namespace PubComp.Caching.Core.UnitTests
         [TestInitialize]
         public void TestInitialize()
         {
-            CacheManager.ConfigLoader = null;
+            CacheManager.Settings = null;
             CacheManager.CacheManagerLogic = null;
             CacheManager.RemoveAllCaches();
         }

--- a/Core.UnitTests/CacheManagerTests.cs
+++ b/Core.UnitTests/CacheManagerTests.cs
@@ -11,7 +11,6 @@ namespace PubComp.Caching.Core.UnitTests
         {
             CacheManager.Settings = null;
             CacheManager.CacheManagerLogic = null;
-            CacheManager.RemoveAllCaches();
         }
 
         [TestMethod]

--- a/Core.UnitTests/CacheManagerTests.cs
+++ b/Core.UnitTests/CacheManagerTests.cs
@@ -9,6 +9,8 @@ namespace PubComp.Caching.Core.UnitTests
         [TestInitialize]
         public void TestInitialize()
         {
+            CacheManager.ConfigLoader = null;
+            CacheManager.CacheManagerLogic = null;
             CacheManager.RemoveAllCaches();
         }
 

--- a/Core.UnitTests/Core.UnitTests.csproj
+++ b/Core.UnitTests/Core.UnitTests.csproj
@@ -19,6 +19,12 @@
     <ProjectReference Include="..\SystemRuntime\SystemRuntime.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="unittests_pubcompcachesettings_override2.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="unittests_pubcompcachesettings_override1.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="unittests_pubcompcachesettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Core.UnitTests/Core.UnitTests.csproj
+++ b/Core.UnitTests/Core.UnitTests.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>PubComp.Caching.Core.UnitTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
@@ -16,5 +17,10 @@
     <ProjectReference Include="..\Core\Core.csproj" />
     <ProjectReference Include="..\AopCaching\AopCaching.csproj" />
     <ProjectReference Include="..\SystemRuntime\SystemRuntime.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="unittests_pubcompcachesettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Core.UnitTests/LayeredCacheTests.cs
+++ b/Core.UnitTests/LayeredCacheTests.cs
@@ -12,7 +12,6 @@ namespace PubComp.Caching.Core.UnitTests
         {
             CacheManager.Settings = null;
             CacheManager.CacheManagerLogic = null;
-            CacheManager.RemoveAllCaches();
         }
 
         [TestMethod]

--- a/Core.UnitTests/LayeredCacheTests.cs
+++ b/Core.UnitTests/LayeredCacheTests.cs
@@ -7,6 +7,14 @@ namespace PubComp.Caching.Core.UnitTests
     [TestClass]
     public class LayeredCacheTests
     {
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            CacheManager.ConfigLoader = null;
+            CacheManager.CacheManagerLogic = null;
+            CacheManager.RemoveAllCaches();
+        }
+
         [TestMethod]
         public void TestLayeredCacheValidInnerCaches()
         {

--- a/Core.UnitTests/LayeredCacheTests.cs
+++ b/Core.UnitTests/LayeredCacheTests.cs
@@ -10,7 +10,7 @@ namespace PubComp.Caching.Core.UnitTests
         [TestInitialize]
         public void TestInitialize()
         {
-            CacheManager.ConfigLoader = null;
+            CacheManager.Settings = null;
             CacheManager.CacheManagerLogic = null;
             CacheManager.RemoveAllCaches();
         }

--- a/Core.UnitTests/MockConfigLoaderTests.cs
+++ b/Core.UnitTests/MockConfigLoaderTests.cs
@@ -1,0 +1,46 @@
+﻿using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PubComp.Caching.Core.UnitTests.Mocks;
+
+namespace PubComp.Caching.Core.UnitTests
+{
+    [TestClass]
+    public class MockConfigLoaderTests
+    {
+        private CacheManagerLogic _cacheManagerLogic;
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            var settings = new CacheManagerSettings
+            {
+                ConfigLoader = new MockCacheConfigLoader()
+            };
+            _cacheManagerLogic = new CacheManagerLogic(settings);
+            _cacheManagerLogic.InitializeFromConfig();
+        }
+
+        [TestMethod]
+        public void TestConfigLoader()
+        {
+            Assert.IsNotNull(_cacheManagerLogic);
+            Assert.IsNotNull(_cacheManagerLogic.Settings);
+            Assert.IsInstanceOfType(_cacheManagerLogic.Settings.ConfigLoader, typeof(MockCacheConfigLoader));
+        }
+
+        [TestMethod]
+        public void TestCaches()
+        {
+            var cacheNames = _cacheManagerLogic.GetCacheNames();
+
+            Assert.AreEqual(2, cacheNames.Count());
+            var cache1 = _cacheManagerLogic.GetCache("mockCache1");
+            Assert.IsNotNull(cache1);
+            Assert.IsInstanceOfType(cache1, typeof(MockNoCache));
+            var cache2 = _cacheManagerLogic.GetCache("mockCache2");
+            Assert.IsNotNull(cache2);
+            Assert.IsInstanceOfType(cache2, typeof(MockNoCache));
+            var cacheNotExist = _cacheManagerLogic.GetCache("mockCache3");
+            Assert.IsNull(cacheNotExist);
+        }
+    }
+}

--- a/Core.UnitTests/MockConfigLoaderTests.cs
+++ b/Core.UnitTests/MockConfigLoaderTests.cs
@@ -8,6 +8,7 @@ namespace PubComp.Caching.Core.UnitTests
     public class MockConfigLoaderTests
     {
         private CacheManagerLogic _cacheManagerLogic;
+
         [TestInitialize]
         public void TestInitialize()
         {
@@ -15,6 +16,7 @@ namespace PubComp.Caching.Core.UnitTests
             {
                 ConfigLoader = new MockCacheConfigLoader()
             };
+
             _cacheManagerLogic = new CacheManagerLogic(settings);
             _cacheManagerLogic.InitializeFromConfig();
         }

--- a/Core.UnitTests/Mocks/MockCacheConfigLoader.cs
+++ b/Core.UnitTests/Mocks/MockCacheConfigLoader.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using PubComp.Caching.Core.Config;
+using PubComp.Caching.Core.Config.Loaders;
+
+namespace PubComp.Caching.Core.UnitTests.Mocks
+{
+    public class MockCacheConfigLoader : ICacheConfigLoader
+    {
+        public IList<ConfigNode> LoadConfig()
+        {
+            var c1 = new MockNoCacheConfig
+                { Action = ConfigAction.Add, Name = "mockCache1", Policy = new MockCachePolicy() };
+            var c2 = new MockNoCacheConfig
+                { Action = ConfigAction.Add, Name = "mockCache2", Policy = new MockCachePolicy() };
+            return new List<ConfigNode> {c1, c2};
+        }
+    }
+}

--- a/Core.UnitTests/NoCacheTests.cs
+++ b/Core.UnitTests/NoCacheTests.cs
@@ -54,7 +54,12 @@ namespace PubComp.Caching.Core.UnitTests
 
             int hits = 0;
 
-            Func<Task<string>> getter = async () => { hits++; return hits.ToString(); };
+            Func<Task<string>> getter = async () =>
+            {
+                await Task.Delay(10);
+                hits++;
+                return hits.ToString();
+            };
 
             string result;
 

--- a/Core.UnitTests/unittests_pubcompcachesettings.json
+++ b/Core.UnitTests/unittests_pubcompcachesettings.json
@@ -1,88 +1,41 @@
 {
   "PubComp": {
-    "CacheConfig": [
-      {
-        "name": "cacheFromConfig1",
+    "CacheConfig": {
+      "cacheFromConfig1": {
         "assembly": "PubComp.Caching.Core",
         "type": "NoCache"
       },
-      {
-        "action": "Add",
-        "name": "cacheFromConfig2",
-        "assembly": "PubComp.Caching.Core",
-        "type": "NoCache"
-      },
-      {
-        "action": "Remove",
-        "name": "cacheFromConfig2"
-      },
-      {
-        "name": "cacheFromConfig2",
+      "cacheFromConfig2": {
         "assembly": "PubComp.Caching.Core.UnitTests",
         "type": "PubComp.Caching.Core.UnitTests.Mocks.MockNoCache",
         "policy": {
           "SlidingExpiration": "00:15:00"
         }
       },
-      {
-        "name": "cacheFromConfig3",
+      "cacheFromConfig3": {
         "assembly": "PubComp.Caching.Core",
         "type": "NoCache"
       },
-      {
-        "action": "Remove",
-        "name": "cacheFromConfig3"
-      },
-      {
-        "name": "localRedisUrl",
+      "localRedisUrl": {
         "assembly": "PubComp.Caching.Core.UnitTests",
         "type": "Mocks.PlainConnectionString",
         "connectionString": "127.0.0.1:1234,serviceName=mymaster"
       },
-      {
-        "action": "Remove",
-        "name": "localRedisUrl"
-      },
-      {
-        "action": "Remove",
-        "name": "cacheFromConfig4"
-      },
-      {
-        "action": "Add",
-        "name": "localRedisUrl",
-        "assembly": "PubComp.Caching.Core.UnitTests",
-        "type": "Mocks.PlainConnectionString",
-        "connectionString": "127.0.0.1:6379,serviceName=mymaster"
-      },
-      {
-        "name": "localRedisUrlEnc",
+      "localRedisUrlEnc": {
         "assembly": "PubComp.Caching.Core.UnitTests",
         "type": "Mocks.UrlEncConnectionString",
         "encConnectionString": "127.0.0.1%3A6379%2CserviceName%3Dmymaster"
       },
-      {
-        "name": "noNotifier",
-        "assembly": "PubComp.Caching.Core.UnitTests",
-        "type": "Mocks.NoNotifier",
-        "policy": { "ConnectionName": "localRedisUrl" }
-      },
-      {
-        "action": "Remove",
-        "name": "noNotifier"
-      },
-      {
-        "action": "Add",
-        "name": "localRedisB64Enc",
+      "localRedisB64Enc": {
         "assembly": "PubComp.Caching.Core.UnitTests",
         "type": "Mocks.B64EncConnectionString",
         "encConnectionString": "MTI3LjAuMC4xOjYzNzksc2VydmljZU5hbWU9bXltYXN0ZXIsYWxsb3dBZG1pbj10cnVl"
       },
-      {
-        "name": "noNotifier",
+      "noNotifier": {
         "assembly": "PubComp.Caching.Core.UnitTests",
         "type": "Mocks.NoNotifier",
-        "policy": { "ConnectionName": "localRedisB64Enc" }
+        "policy": { "ConnectionName": "localRedisUrl" }
       }
-    ]
+    }
   }
 }

--- a/Core.UnitTests/unittests_pubcompcachesettings.json
+++ b/Core.UnitTests/unittests_pubcompcachesettings.json
@@ -1,0 +1,88 @@
+{
+  "PubComp": {
+    "CacheConfig": [
+      {
+        "name": "cacheFromConfig1",
+        "assembly": "PubComp.Caching.Core",
+        "type": "NoCache"
+      },
+      {
+        "action": "Add",
+        "name": "cacheFromConfig2",
+        "assembly": "PubComp.Caching.Core",
+        "type": "NoCache"
+      },
+      {
+        "action": "Remove",
+        "name": "cacheFromConfig2"
+      },
+      {
+        "name": "cacheFromConfig2",
+        "assembly": "PubComp.Caching.Core.UnitTests",
+        "type": "PubComp.Caching.Core.UnitTests.Mocks.MockNoCache",
+        "policy": {
+          "SlidingExpiration": "00:15:00"
+        }
+      },
+      {
+        "name": "cacheFromConfig3",
+        "assembly": "PubComp.Caching.Core",
+        "type": "NoCache"
+      },
+      {
+        "action": "Remove",
+        "name": "cacheFromConfig3"
+      },
+      {
+        "name": "localRedisUrl",
+        "assembly": "PubComp.Caching.Core.UnitTests",
+        "type": "Mocks.PlainConnectionString",
+        "connectionString": "127.0.0.1:1234,serviceName=mymaster"
+      },
+      {
+        "action": "Remove",
+        "name": "localRedisUrl"
+      },
+      {
+        "action": "Remove",
+        "name": "cacheFromConfig4"
+      },
+      {
+        "action": "Add",
+        "name": "localRedisUrl",
+        "assembly": "PubComp.Caching.Core.UnitTests",
+        "type": "Mocks.PlainConnectionString",
+        "connectionString": "127.0.0.1:6379,serviceName=mymaster"
+      },
+      {
+        "name": "localRedisUrlEnc",
+        "assembly": "PubComp.Caching.Core.UnitTests",
+        "type": "Mocks.UrlEncConnectionString",
+        "encConnectionString": "127.0.0.1%3A6379%2CserviceName%3Dmymaster"
+      },
+      {
+        "name": "noNotifier",
+        "assembly": "PubComp.Caching.Core.UnitTests",
+        "type": "Mocks.NoNotifier",
+        "policy": { "ConnectionName": "localRedisUrl" }
+      },
+      {
+        "action": "Remove",
+        "name": "noNotifier"
+      },
+      {
+        "action": "Add",
+        "name": "localRedisB64Enc",
+        "assembly": "PubComp.Caching.Core.UnitTests",
+        "type": "Mocks.B64EncConnectionString",
+        "encConnectionString": "MTI3LjAuMC4xOjYzNzksc2VydmljZU5hbWU9bXltYXN0ZXIsYWxsb3dBZG1pbj10cnVl"
+      },
+      {
+        "name": "noNotifier",
+        "assembly": "PubComp.Caching.Core.UnitTests",
+        "type": "Mocks.NoNotifier",
+        "policy": { "ConnectionName": "localRedisB64Enc" }
+      }
+    ]
+  }
+}

--- a/Core.UnitTests/unittests_pubcompcachesettings_override1.json
+++ b/Core.UnitTests/unittests_pubcompcachesettings_override1.json
@@ -1,0 +1,15 @@
+{
+  "PubComp": {
+    "CacheConfig": {
+      "cacheFromConfig3": {
+        "action": "Remove"
+      },
+      "localRedisUrl": {
+        "connectionString": "127.0.0.1:6379,serviceName=mymaster"
+      },
+      "noNotifier": {
+        "action": "Remove"
+      }
+    }
+  }
+}

--- a/Core.UnitTests/unittests_pubcompcachesettings_override2.json
+++ b/Core.UnitTests/unittests_pubcompcachesettings_override2.json
@@ -1,0 +1,14 @@
+{
+  "PubComp": {
+    "CacheConfig": {
+      "noNotifier": {
+        "action": "Add",
+        "assembly": "PubComp.Caching.Core.UnitTests",
+        "type": "Mocks.NoNotifier",
+        "policy": {
+          "ConnectionName": "localRedisB64Enc"
+        }
+      }
+    }
+  }
+}

--- a/Core/CacheConfigurationHandler.cs
+++ b/Core/CacheConfigurationHandler.cs
@@ -12,10 +12,12 @@ namespace PubComp.Caching.Core
 {
     public class CacheConfigurationHandler : IConfigurationSectionHandler
     {
-        private readonly CacheConfigLoadErrorsException cacheConfigLoadErrorsException = new CacheConfigLoadErrorsException();
+        private CacheConfigLoadErrorsException cacheConfigLoadErrorsException;
 
         public object Create(object parent, object configContext, System.Xml.XmlNode section)
         {
+            cacheConfigLoadErrorsException = new CacheConfigLoadErrorsException();
+
             var assemblies = new Dictionary<string, Assembly>();
             var configuration = new List<ConfigNode>();
 
@@ -71,7 +73,7 @@ namespace PubComp.Caching.Core
                         assembly = Assembly.Load(assemblyNode.Value);
                     }
                     catch (Exception ex) when (ex is FileLoadException ||
-                                               ex is FileNotFoundException || // Was FileNotFoundException missing on purpose?
+                                               ex is FileNotFoundException ||
                                                ex is BadImageFormatException)
                     {
                         LogConfigError($"Could not load assembly {assemblyNode.Value}", ex);

--- a/Core/CacheConfigurationHandler.cs
+++ b/Core/CacheConfigurationHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Configuration;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -68,12 +69,9 @@ namespace PubComp.Caching.Core
                     {
                         assembly = Assembly.Load(assemblyNode.Value);
                     }
-                    catch (System.IO.FileLoadException ex)
-                    {
-                        LogConfigError($"Could not load assembly {assemblyNode.Value}", ex);
-                        continue;
-                    }
-                    catch (System.BadImageFormatException ex)
+                    catch (Exception ex) when (ex is FileLoadException ||
+                                               ex is FileNotFoundException ||
+                                               ex is BadImageFormatException)
                     {
                         LogConfigError($"Could not load assembly {assemblyNode.Value}", ex);
                         continue;

--- a/Core/CacheConfigurationHandler.cs
+++ b/Core/CacheConfigurationHandler.cs
@@ -6,11 +6,14 @@ using System.Linq;
 using System.Reflection;
 using System.Xml;
 using PubComp.Caching.Core.Config;
+using PubComp.Caching.Core.Config.Loaders;
 
 namespace PubComp.Caching.Core
 {
     public class CacheConfigurationHandler : IConfigurationSectionHandler
     {
+        private readonly CacheConfigLoadErrorsException cacheConfigLoadErrorsException = new CacheConfigLoadErrorsException();
+
         public object Create(object parent, object configContext, System.Xml.XmlNode section)
         {
             var assemblies = new Dictionary<string, Assembly>();
@@ -113,6 +116,9 @@ namespace PubComp.Caching.Core
                 ApplyConfig(configuration, child.Attributes, configType, action, configNode);
             }
 
+            if (!cacheConfigLoadErrorsException.IsEmpty())
+                throw cacheConfigLoadErrorsException;
+
             return configuration;
         }
 
@@ -189,6 +195,9 @@ namespace PubComp.Caching.Core
                 System.Diagnostics.Debug.WriteLine(
                     $"{typeof(CacheConfigurationHandler).FullName}: {error}");
             }
+
+            cacheConfigLoadErrorsException.Add(new CacheConfigLoadErrorsException.CacheConfigLoadError
+                { Error = error, Exception = ex });
         }
     }
 }

--- a/Core/CacheConfigurationHandler.cs
+++ b/Core/CacheConfigurationHandler.cs
@@ -12,6 +12,7 @@ namespace PubComp.Caching.Core
 {
     public class CacheConfigurationHandler : IConfigurationSectionHandler
     {
+        // TODO: move this to a local variable
         private CacheConfigLoadErrorsException cacheConfigLoadErrorsException;
 
         public object Create(object parent, object configContext, System.Xml.XmlNode section)

--- a/Core/CacheConfigurationHandler.cs
+++ b/Core/CacheConfigurationHandler.cs
@@ -11,6 +11,8 @@ namespace PubComp.Caching.Core
 {
     public class CacheConfigurationHandler : IConfigurationSectionHandler
     {
+        private readonly Dictionary<string, Assembly> _assemblies = new Dictionary<string, Assembly>();
+
         public object Create(object parent, object configContext, System.Xml.XmlNode section)
         {
             var configuration = new List<ConfigNode>();
@@ -60,19 +62,24 @@ namespace PubComp.Caching.Core
 
                 Assembly assembly;
 
-                try
+                if (!_assemblies.TryGetValue(assemblyNode.Value, out assembly))
                 {
-                    assembly = Assembly.Load(assemblyNode.Value);
-                }
-                catch (System.IO.FileLoadException ex)
-                {
-                    LogConfigError($"Could not load assembly {assemblyNode.Value}", ex);
-                    continue;
-                }
-                catch (System.BadImageFormatException ex)
-                {
-                    LogConfigError($"Could not load assembly {assemblyNode.Value}", ex);
-                    continue;
+                    try
+                    {
+                        assembly = Assembly.Load(assemblyNode.Value);
+                    }
+                    catch (System.IO.FileLoadException ex)
+                    {
+                        LogConfigError($"Could not load assembly {assemblyNode.Value}", ex);
+                        continue;
+                    }
+                    catch (System.BadImageFormatException ex)
+                    {
+                        LogConfigError($"Could not load assembly {assemblyNode.Value}", ex);
+                        continue;
+                    }
+
+                    _assemblies.Add(assemblyNode.Value, assembly);
                 }
 
                 var configType = assembly.GetType(typeName, false, false);

--- a/Core/CacheControllerUtil.cs
+++ b/Core/CacheControllerUtil.cs
@@ -247,6 +247,14 @@ namespace PubComp.Caching.Core
         }
 
         /// <summary>
+        /// Clears all registrations of named caches
+        /// </summary>
+        internal void ClearRegisteredCacheNames()
+        {
+            RegisteredCacheNames.Clear();
+        }
+
+        /// <summary>
         /// Gets names of all registered cache instances
         /// </summary>
         public IEnumerable<string> GetRegisteredCacheNames()

--- a/Core/CacheManager.cs
+++ b/Core/CacheManager.cs
@@ -37,7 +37,7 @@ namespace PubComp.Caching.Core
                     {
                         if (_innerCacheManagerInstance == null)
                         {
-                            _innerCacheManagerInstance = new CacheManagerLogic(ConfigLoader);
+                            _innerCacheManagerInstance = new CacheManagerLogic(Settings);
                             _innerCacheManagerInstance.InitializeFromConfig();
                         }
                     }
@@ -54,12 +54,14 @@ namespace PubComp.Caching.Core
         #endregion
 
         /// <summary>
+        /// The initialization time settings for the Cache Manager.
         /// The source from which the entire cache configuration will be loaded from.
         /// The default value is to use System.ConfigurationManager internally to load from app/web.config
+        /// Also default is to not register automatically all the cache names with CacheControllerUtil
         /// This setting should be set before any call to the API methods
         /// </summary>
-        // TODO: replace with an entire CacheManagerSettings class (in ctor)
-        public static ICacheConfigLoader ConfigLoader { get; set; } = new SystemConfigurationManagerCacheConfigLoader();
+        public static CacheManagerSettings Settings { get; set; } = new CacheManagerSettings
+            {ConfigLoader = new SystemConfigurationManagerCacheConfigLoader(), ShouldRegisterAllCaches = false};
 
         #region Cache access API
 

--- a/Core/CacheManager.cs
+++ b/Core/CacheManager.cs
@@ -1,53 +1,52 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Configuration;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using PubComp.Caching.Core.Config;
+using PubComp.Caching.Core.Config.Loaders;
 using PubComp.Caching.Core.Notifications;
 
 namespace PubComp.Caching.Core
 {
+    // TODO: Add XML comments
+    // TODO: Create interfaces
     public class CacheManager
     {
-        private static Func<MethodBase> callingMethodGetter;
+        #region innerInstance
 
-        //ReSharper disable once InconsistentNaming
-        private static readonly SemaphoreSlim cachesSync
-            = new SemaphoreSlim(1, 1);
+        private static CacheManagerLogic _innerCacheManagerInstance;
+        private static readonly object _instanceGeneratorLock = new object();
 
-        // ReSharper disable once InconsistentNaming
-        private static readonly ConcurrentDictionary<CacheName, ICache> caches
-            = new ConcurrentDictionary<CacheName, ICache>();
-
-        // ReSharper disable once InconsistentNaming
-        private static readonly ReaderWriterLockSlim notifiersSync
-            = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
-
-        // ReSharper disable once InconsistentNaming
-        private static readonly ConcurrentDictionary<string, ICacheNotifier> notifiers
-            = new ConcurrentDictionary<string, ICacheNotifier>();
-
-        // ReSharper disable once InconsistentNaming
-        private static readonly ReaderWriterLockSlim connectionStringsSync
-            = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
-
-        // ReSharper disable once InconsistentNaming
-        private static readonly ConcurrentDictionary<string, ICacheConnectionString> connectionStrings
-            = new ConcurrentDictionary<string, ICacheConnectionString>();
-
-        // ReSharper disable once InconsistentNaming
-        private static readonly ConcurrentDictionary<string, string> cacheNofifierAssociations
-            = new ConcurrentDictionary<string, string>();
-
-        static CacheManager()
+        // The reason the logic init is split to CTOR and InitializeFromConfig is
+        // to allow the calls to CacheManager while loading and applying the configuration
+        // TODO: Change to internal to be accessed by unit tests
+        // TODO: Pass ICacheManager or subset to ConfigNode classes that call CacheManager directly
+        public static CacheManagerLogic CacheManagerLogic
         {
-            InitializeFromConfig();
+            get
+            {
+                if (_innerCacheManagerInstance == null)
+                {
+                    lock (_instanceGeneratorLock)
+                    {
+                        if (_innerCacheManagerInstance == null)
+                        {
+                            _innerCacheManagerInstance = new CacheManagerLogic(ConfigLoader);
+                            _innerCacheManagerInstance.InitializeFromConfig();
+                        }
+                    }
+                }
+
+                return _innerCacheManagerInstance;
+            }
+            set
+            {
+                _innerCacheManagerInstance = value;
+            }
         }
+
+        #endregion
+
+        public static ICacheConfigLoader ConfigLoader { get; set; } = new SystemConfigurationManagerCacheConfigLoader();
 
         #region Cache access API
 
@@ -55,165 +54,77 @@ namespace PubComp.Caching.Core
         /// <remarks>For better performance, store the result in client class</remarks>
         public static ICache GetCurrentClassCache()
         {
-            var method = GetCallingMethod();
-            var declaringType = method.DeclaringType;
-            return GetCache(declaringType);
+            return CacheManagerLogic.GetCurrentClassCache();
         }
 
         /// <summary>Gets a cache instance using full name of given class</summary>
         /// <remarks>For better performance, store the result in client class</remarks>
         public static ICache GetCache<TClass>()
         {
-            return GetCache(typeof(TClass));
+            return CacheManagerLogic.GetCache<TClass>();
         }
 
         /// <summary>Gets a cache instance using full name of given class</summary>
         /// <remarks>For better performance, store the result in client class</remarks>
         public static ICache GetCache(Type type)
         {
-            return GetCache(type.FullName);
+            return CacheManagerLogic.GetCache(type);
         }
 
         /// <summary>Gets a list of all cache names</summary>
         /// <remarks>For better performance, store the result in client class</remarks>
         public static IEnumerable<string> GetCacheNames()
         {
-            string[] names;
-
-            cachesSync.Wait();
-            try
-            {
-                names = caches.Values.Select(v => v.Name).ToArray();
-            }
-            finally
-            {
-                cachesSync.Release();
-            }
-
-            return names;
+            return CacheManagerLogic.GetCacheNames();
         }
 
         /// <summary>Gets a cache by name</summary>
         /// <remarks>For better performance, store the result in client class</remarks>
         public static ICache GetCache(string name)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-
-            var cachesArray = GetCaches();
-            
-            var cachesSorted = cachesArray.OrderByDescending(c => c.Key.GetMatchLevel(name));
-            var cache = cachesSorted.FirstOrDefault();
-
-            return (cache.Key.Prefix != null && cache.Key.GetMatchLevel(name) >= cache.Key.Prefix.Length) ? cache.Value : null;
+            return CacheManagerLogic.GetCache(name);
         }
 
         /// <summary>Gets a cache by name</summary>
         /// <remarks>For better performance, store the result in client class</remarks>
         public static async Task<ICache> GetCacheAsync(string name)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-
-            var cachesArray = await GetCachesAsync().ConfigureAwait(false);
-            
-            var cachesSorted = cachesArray.OrderByDescending(c => c.Key.GetMatchLevel(name));
-            var cache = cachesSorted.FirstOrDefault();
-
-            return (cache.Key.Prefix != null && cache.Key.GetMatchLevel(name) >= cache.Key.Prefix.Length) ? cache.Value : null;
+            return await CacheManagerLogic.GetCacheAsync(name).ConfigureAwait(false);
         }
 
         /// <summary>Gets a cache by name - return a specialized cache implementation type</summary>
         /// <remarks>For better performance, store the result in client class</remarks>
         public static TCache GetCache<TCache>(string name) where TCache : ICache
         {
-            var cache = GetCache(name);
-            if (!(cache is TCache))
-                throw new ArgumentException("The specified cache is not of type " + typeof(TCache));
-
-            return (TCache)cache;
+            return CacheManagerLogic.GetCache<TCache>(name);
         }
 
         /// <summary>Gets a list of all notifier names</summary>
         /// <remarks>For better performance, store the result in client class</remarks>
         public static IEnumerable<string> GetNotifierNames()
         {
-            string[] names;
-
-            notifiersSync.EnterReadLock();
-            try
-            {
-                names = notifiers.Values.Select(v => v.Name).ToArray();
-            }
-            finally
-            {
-                notifiersSync.ExitReadLock();
-            }
-
-            return names;
+            return CacheManagerLogic.GetNotifierNames();
         }
 
         /// <summary>Gets a notifier by name</summary>
         /// <remarks>For better performance, store the result in client class</remarks>
         public static ICacheNotifier GetNotifier(string name)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-
-            ICacheNotifier result;
-
-            notifiersSync.EnterReadLock();
-            try
-            {
-                notifiers.TryGetValue(name, out result);
-            }
-            finally
-            {
-                notifiersSync.ExitReadLock();
-            }
-
-            return result;
+            return CacheManagerLogic.GetNotifier(name);
         }
 
         /// <summary>Gets a list of all connection string names</summary>
         /// <remarks>For better performance, store the result in client class</remarks>
         public static IEnumerable<string> GetConnectionStringNames()
         {
-            string[] names;
-
-            connectionStringsSync.EnterReadLock();
-            try
-            {
-                names = connectionStrings.Values.Select(v => v.Name).ToArray();
-            }
-            finally
-            {
-                connectionStringsSync.ExitReadLock();
-            }
-
-            return names;
+            return CacheManagerLogic.GetConnectionStringNames();
         }
 
         /// <summary>Gets a connection string by name</summary>
         /// <remarks>For better performance, store the result in client class</remarks>
         public static ICacheConnectionString GetConnectionString(string name)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-
-            ICacheConnectionString result;
-
-            connectionStringsSync.EnterReadLock();
-            try
-            {
-                connectionStrings.TryGetValue(name, out result);
-            }
-            finally
-            {
-                connectionStringsSync.ExitReadLock();
-            }
-
-            return result;
+            return CacheManagerLogic.GetConnectionString(name);
         }
 
         /// <summary>Associates a cache with a notifier</summary>
@@ -221,8 +132,7 @@ namespace PubComp.Caching.Core
         /// <param name="notifier"></param>
         public static void Associate(ICache cache, ICacheNotifier notifier)
         {
-            cacheNofifierAssociations.AddOrUpdate(
-                cache.Name, c => notifier.Name, (c, n) => notifier.Name);
+            CacheManagerLogic.Associate(cache, notifier);
         }
 
         /// <summary>Gets the notifier that was associated with a cahe</summary>
@@ -230,383 +140,113 @@ namespace PubComp.Caching.Core
         /// <returns></returns>
         public static ICacheNotifier GetAssociatedNotifier(ICache cache)
         {
-            return cacheNofifierAssociations.TryGetValue(cache.Name, out string notifierName)
-                ? GetNotifier(notifierName)
-                : null;
+            return CacheManagerLogic.GetAssociatedNotifier(cache);
         }
 
         #endregion
 
-        private static KeyValuePair<CacheName, ICache>[] GetCaches()
-        {
-            KeyValuePair<CacheName, ICache>[] cachesArray;
-
-            cachesSync.Wait();
-            try
-            {
-                cachesArray = caches.ToArray();
-            }
-            finally
-            {
-                cachesSync.Release();
-            }
-
-            return cachesArray;
-        }
-
-        private static async Task<KeyValuePair<CacheName, ICache>[]> GetCachesAsync()
-        {
-            KeyValuePair<CacheName, ICache>[] cachesArray;
-
-            await cachesSync.WaitAsync().ConfigureAwait(false);
-            try
-            {
-                cachesArray = caches.ToArray();
-            }
-            finally
-            {
-                cachesSync.Release();
-            }
-
-            return cachesArray;
-        }
-
-        private static void SyncSet(ReaderWriterLockSlim syncObj, Action action)
-        {
-            syncObj.EnterWriteLock();
-            try
-            {
-                action();
-            }
-            finally
-            {
-                syncObj.ExitWriteLock();
-            }
-        }
-
-        private static void SyncSet(SemaphoreSlim syncObj, Action action)
-        {
-            syncObj.Wait();
-            try
-            {
-                action();
-            }
-            finally
-            {
-                syncObj.Release();
-            }
-        }
-
         #region Cache configuration API
 
         /// <summary>
-        /// Sets named cached according to application config (app.config/web.config)
-        /// This method is called automatically by static constructor.
+        /// Sets named cached according to set config loader
+        /// This method is called automatically once by inner instance getter.
         /// Initialization cab be overriden using SetCache and RemoveCache (and this method)
         /// </summary>
         public static void InitializeFromConfig()
         {
-            var config = LoadConfig();
-            ApplyConfig(config);
+            CacheManagerLogic.InitializeFromConfig();
         }
 
         /// <summary>
         /// Adds or sets a cache by name
-        /// This method is to be used during application intialization, it does not delete or replace the cache if already in use!
+        /// This method is to be used during application initialization, it does not delete or replace the cache if already in use!
         /// </summary>
         /// <param name="name"></param>
         /// <param name="cache"></param>
         /// <remarks>Cache name can end with wildcard '*'</remarks>
         public static void SetCache(string name, ICache cache)
         {
-            var cacheName = new CacheName(name);
-
-            void Action()
-            {
-                if (cache == null)
-                {
-                    // ReSharper disable once UnusedVariable
-                    caches.TryRemove(cacheName, out var oldValue);
-                }
-                else
-                {
-                    caches.AddOrUpdate(cacheName, cache, (k, v) => cache);
-                }
-            }
-
-            SyncSet(cachesSync, Action);
+            CacheManagerLogic.SetCache(name, cache);
         }
 
         /// <summary>
         /// Removes a cache registration with a given name.
-        /// This method is to be used during application intialization, it does not delete or replace the cache if already in use!
+        /// This method is to be used during application initialization, it does not delete or replace the cache if already in use!
         /// </summary>
         /// <param name="name"></param>
         public static void RemoveCache(string name)
         {
-            var cacheName = new CacheName(name);
-
-            void Action()
-            {
-                // ReSharper disable once UnusedVariable
-                caches.TryRemove(cacheName, out var oldValue);
-            }
-
-            SyncSet(cachesSync, Action);
+            CacheManagerLogic.RemoveCache(name);
         }
 
         /// <summary>
         /// Removes all cache registrations with any given name.
-        /// This method is to be used during application intialization, it does not delete or replace the cache if already in use!
+        /// This method is to be used during application initialization, it does not delete or replace the cache if already in use!
         /// </summary>
         public static void RemoveAllCaches()
         {
-            void Action()
-            {
-                caches.Clear();
-            }
-
-            SyncSet(cachesSync, Action);
+            CacheManagerLogic.RemoveAllCaches();
         }
 
         /// <summary>
         /// Adds or sets a cache by name
-        /// This method is to be used during application intialization, it does not delete or replace the cache if already in use!
+        /// This method is to be used during application initialization, it does not delete or replace the cache if already in use!
         /// </summary>
         /// <param name="name"></param>
         /// <param name="connectionString"></param>
         /// <remarks>Cache name can end with wildcard '*'</remarks>
         public static void SetConnectionString(string name, ICacheConnectionString connectionString)
         {
-            void Action()
-            {
-                if (connectionString == null)
-                {
-                    // ReSharper disable once UnusedVariable
-                    connectionStrings.TryRemove(name, out var oldValue);
-                }
-                else
-                {
-                    connectionStrings.AddOrUpdate(name, connectionString, (k, v) => connectionString);
-                }
-            }
-
-            SyncSet(connectionStringsSync, Action);
+            CacheManagerLogic.SetConnectionString(name, connectionString);
         }
 
         /// <summary>
         /// Removes a cache registration with a given name.
-        /// This method is to be used during application intialization, it does not delete or replace the cache if already in use!
+        /// This method is to be used during application initialization, it does not delete or replace the cache if already in use!
         /// </summary>
         /// <param name="name"></param>
         public static void RemoveConnectionString(string name)
         {
-            void Action()
-            {
-                // ReSharper disable once UnusedVariable
-                connectionStrings.TryRemove(name, out var oldValue);
-            }
-
-            SyncSet(connectionStringsSync, Action);
+            CacheManagerLogic.RemoveConnectionString(name);
         }
 
         /// <summary>
         /// Removes all cache registrations with any given name.
-        /// This method is to be used during application intialization, it does not delete or replace the cache if already in use!
+        /// This method is to be used during application initialization, it does not delete or replace the cache if already in use!
         /// </summary>
         public static void RemoveAllConnectionStrings()
         {
-            void Action()
-            {
-                connectionStrings.Clear();
-            }
-
-            SyncSet(connectionStringsSync, Action);
+            CacheManagerLogic.RemoveAllConnectionStrings();
         }
 
         /// <summary>
         /// Adds or sets a notifier by name
-        /// This method is to be used during application intialization, it does not delete or replace the notifier if already in use!
+        /// This method is to be used during application initialization, it does not delete or replace the notifier if already in use!
         /// </summary>
         /// <param name="name"></param>
         /// <param name="notifier"></param>
         public static void SetNotifier(string name, ICacheNotifier notifier)
         {
-            void Action()
-            {
-                if (notifier == null)
-                {
-                    // ReSharper disable once UnusedVariable
-                    notifiers.TryRemove(name, out var oldValue);
-                }
-                else
-                {
-                    notifiers.AddOrUpdate(name, notifier, (k, v) => notifier);
-                }
-            }
-
-            SyncSet(notifiersSync, Action);
+            CacheManagerLogic.SetNotifier(name, notifier);
         }
 
         /// <summary>
         /// Removes a notifier registration with a given name.
-        /// This method is to be used during application intialization, it does not delete or replace the notifier if already in use!
+        /// This method is to be used during application initialization, it does not delete or replace the notifier if already in use!
         /// </summary>
         /// <param name="name"></param>
         public static void RemoveNotifier(string name)
         {
-            void Action()
-            {
-                // ReSharper disable once UnusedVariable
-                notifiers.TryRemove(name, out var oldValue);
-            }
-
-            SyncSet(notifiersSync, Action);
+            CacheManagerLogic.RemoveNotifier(name);
         }
 
         /// <summary>
         /// Removes all notifier registrations with any given name.
-        /// This method is to be used during application intialization, it does not delete or replace the notifier if already in use!
+        /// This method is to be used during application initialization, it does not delete or replace the notifier if already in use!
         /// </summary>
         public static void RemoveAllNotifiers()
         {
-            void Action()
-            {
-                notifiers.Clear();
-            }
-
-            SyncSet(notifiersSync, Action);
-        }
-
-        #endregion
-
-        #region Automatic cache naming
-
-        // ReSharper disable once InconsistentNaming
-        private static readonly object loadLock = new object();
-
-        private static MethodBase GetCallingMethod()
-        {
-            Func<MethodBase> method = callingMethodGetter;
-            if (method == null)
-            {
-                lock (loadLock)
-                {
-                    if (callingMethodGetter == null)
-                        callingMethodGetter = CreateGetClassNameFunction();
-
-                    method = callingMethodGetter;
-                }
-            }
-            return method();
-        }
-
-        private static Func<MethodBase> CreateGetClassNameFunction()
-        {
-            var stackFrameType = Type.GetType("System.Diagnostics.StackFrame");
-            if (stackFrameType == null)
-                throw new PlatformNotSupportedException("CreateGetClassNameFunction is only supported on platforms where System.Diagnostics.StackFrame exist");
-
-            var constructor = stackFrameType.GetConstructor(new[] { typeof(int) });
-            var getMethodMethod = stackFrameType.GetMethod("GetMethod");
-
-            if (constructor == null)
-                throw new PlatformNotSupportedException("StackFrame(int skipFrames) constructor not present");
-            
-            if (getMethodMethod == null)
-                throw new PlatformNotSupportedException("StackFrame.GetMethod() not present");
-
-            var stackFrame = Expression.New(constructor, Expression.Constant(3));
-            var method = Expression.Call(stackFrame, getMethodMethod);
-            var lambda = Expression.Lambda<Func<MethodBase>>(method);
-            var compileFunction = lambda.GetType().GetMethod("Compile", new Type[0]);
-            var function = (Func<MethodBase>)compileFunction.Invoke(lambda, null);
-
-            return function;
-        }
-
-        #endregion
-
-        #region Config Loading
-
-        private static IList<ConfigNode> LoadConfig()
-        {
-            var config = ConfigurationManager.GetSection("PubComp/CacheConfig") as IList<ConfigNode>;
-            return config;
-        }
-
-        private static void ApplyConfig(IList<ConfigNode> config)
-        {
-            if (config == null)
-                return;
-
-            var connectionConfigs = new List<ConnectionStringConfig>();
-            var notifierConfigs = new List<NotifierConfig>();
-            var cacheConfigs = new List<CacheConfig>();
-            var connectionRemoveIndexes = new List<int>();
-            var notifierRemoveIndexes = new List<int>();
-            var cacheRemoveIndexes = new List<int>();
-
-            foreach (var item in config)
-            {
-                switch (item.Action)
-                {
-                    case ConfigAction.Remove:
-                        // Remove existing nodes
-                        RemoveCache(item.Name);
-                        RemoveNotifier(item.Name);
-                        RemoveConnectionString(item.Name);
-
-                        // Save which pending nodes to remove
-                        connectionRemoveIndexes.AddRange(
-                            connectionConfigs.Select((cfg, index) => Tuple.Create(index, cfg))
-                                .Where(c => c.Item2.Name == item.Name).Select(c => c.Item1).Reverse());
-                        notifierRemoveIndexes.AddRange(
-                            notifierConfigs.Select((cfg, index) => Tuple.Create(index, cfg))
-                                .Where(c => c.Item2.Name == item.Name).Select(c => c.Item1).Reverse());
-                        cacheRemoveIndexes.AddRange(
-                            cacheConfigs.Select((cfg, index) => Tuple.Create(index, cfg))
-                                .Where(c => c.Item2.Name == item.Name).Select(c => c.Item1).Reverse());
-                        break;
-
-                    case ConfigAction.Add:
-                        // Add to pending nodes
-                        if (item is CacheConfig cacheConfig)
-                        {
-                            cacheConfigs.Add(cacheConfig);
-                        }
-                        else if (item is NotifierConfig notifierConfig)
-                        {
-                            notifierConfigs.Add(notifierConfig);
-                        }
-                        else if (item is ConnectionStringConfig connectionStringConfig)
-                        {
-                            connectionConfigs.Add(connectionStringConfig);
-                        }
-                        break;
-                }
-            }
-
-            // Remove pending nodes marked for removal
-            cacheRemoveIndexes = cacheRemoveIndexes.OrderByDescending(i => i).ToList();
-            notifierRemoveIndexes = notifierRemoveIndexes.OrderByDescending(i => i).ToList();
-            connectionRemoveIndexes = connectionRemoveIndexes.OrderByDescending(i => i).ToList();
-            foreach (var i in cacheRemoveIndexes)
-                cacheConfigs.RemoveAt(i);
-            foreach (var i in notifierRemoveIndexes)
-                notifierConfigs.RemoveAt(i);
-            foreach (var i in connectionRemoveIndexes)
-                connectionConfigs.RemoveAt(i);
-
-            // Add still pending nodes,
-            // order by types (to enable forward declaration)
-            // and then by appearance in config
-            foreach (var item in connectionConfigs)
-                SetConnectionString(item.Name, item.CreateConnectionString());
-            foreach (var item in notifierConfigs)
-                SetNotifier(item.Name, item.CreateCacheNotifier());
-            foreach (var item in cacheConfigs)
-                SetCache(item.Name, item.CreateCache());
+            CacheManagerLogic.RemoveAllNotifiers();
         }
 
         #endregion

--- a/Core/CacheManager.cs
+++ b/Core/CacheManager.cs
@@ -60,8 +60,12 @@ namespace PubComp.Caching.Core
         /// Also default is to not register automatically all the cache names with CacheControllerUtil
         /// This setting should be set before any call to the API methods
         /// </summary>
-        public static CacheManagerSettings Settings { get; set; } = new CacheManagerSettings
-            {ConfigLoader = new SystemConfigurationManagerCacheConfigLoader(), ShouldRegisterAllCaches = false};
+        public static CacheManagerSettings Settings { get; set; } =
+            new CacheManagerSettings
+            {
+                ConfigLoader = new SystemConfigurationManagerCacheConfigLoader(),
+                ShouldRegisterAllCaches = false
+            };
 
         #region Cache access API
 

--- a/Core/CacheManager.cs
+++ b/Core/CacheManager.cs
@@ -13,7 +13,7 @@ namespace PubComp.Caching.Core
     /// The main manager class to handle all the named caches, connectionStrings and notifiers
     /// It's a singleton instance wrapped around <see cref=" CacheManagerLogic"/>
     /// </summary>
-    public class CacheManager
+    public static class CacheManager
     {
         #region innerInstance
 
@@ -169,7 +169,11 @@ namespace PubComp.Caching.Core
         /// </summary>
         public static void InitializeFromConfig()
         {
-            CacheManagerLogic.InitializeFromConfig();
+            lock (_instanceGeneratorLock)
+            {
+                CacheManagerLogic = null;
+                CacheManagerLogic.ToString(); // Just touch the getter
+            }
         }
 
         /// <summary>

--- a/Core/CacheManager.cs
+++ b/Core/CacheManager.cs
@@ -1,14 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using PubComp.Caching.Core.Config.Loaders;
 using PubComp.Caching.Core.Notifications;
 
+[assembly: InternalsVisibleTo("PubComp.Caching.Core.UnitTests")]
 namespace PubComp.Caching.Core
 {
-    // TODO: Add XML comments
     // TODO: Create interfaces
+    /// <summary>
+    /// The main manager class to handle all the named caches, connectionStrings and notifiers
+    /// It's a singleton instance wrapped around <see cref=" CacheManagerLogic"/>
+    /// </summary>
     public class CacheManager
     {
         #region innerInstance
@@ -18,9 +22,12 @@ namespace PubComp.Caching.Core
 
         // The reason the logic init is split to CTOR and InitializeFromConfig is
         // to allow the calls to CacheManager while loading and applying the configuration
-        // TODO: Change to internal to be accessed by unit tests
+        // i.e. the apply config logic itself sometimes call the CacheManager itself...
         // TODO: Pass ICacheManager or subset to ConfigNode classes that call CacheManager directly
-        public static CacheManagerLogic CacheManagerLogic
+        /// <summary>
+        /// The internal instance of the manager
+        /// </summary>
+        internal static CacheManagerLogic CacheManagerLogic
         {
             get
             {
@@ -46,6 +53,12 @@ namespace PubComp.Caching.Core
 
         #endregion
 
+        /// <summary>
+        /// The source from which the entire cache configuration will be loaded from.
+        /// The default value is to use System.ConfigurationManager internally to load from app/web.config
+        /// This setting should be set before any call to the API methods
+        /// </summary>
+        // TODO: replace with an entire CacheManagerSettings class (in ctor)
         public static ICacheConfigLoader ConfigLoader { get; set; } = new SystemConfigurationManagerCacheConfigLoader();
 
         #region Cache access API

--- a/Core/CacheManagerLogic.cs
+++ b/Core/CacheManagerLogic.cs
@@ -45,7 +45,7 @@ namespace PubComp.Caching.Core
         private ConcurrentDictionary<string, string> cacheNotifierAssociations
             = new ConcurrentDictionary<string, string>();
 
-        public ICacheConfigLoader ConfigLoader { get; private set; } = new SystemConfigurationManagerCacheConfigLoader();
+        public ICacheConfigLoader ConfigLoader { get; private set; }
 
         public CacheManagerLogic(ICacheConfigLoader configLoader)
         {

--- a/Core/CacheManagerLogic.cs
+++ b/Core/CacheManagerLogic.cs
@@ -12,8 +12,12 @@ using PubComp.Caching.Core.Notifications;
 
 namespace PubComp.Caching.Core
 {
-    // TODO: Add XML comments
-    public class CacheManagerLogic
+    /// <summary>
+    /// The main logic class to handle all the named caches, connectionStrings and notifiers.
+    /// The class exist to allow slight decouple from the singleton instance,
+    /// Allowing to make the CacheManager to behave differently based on settings, e.g. source of cache configuration
+    /// </summary>
+    internal class CacheManagerLogic
     {
         private Func<MethodBase> callingMethodGetter;
 
@@ -45,8 +49,17 @@ namespace PubComp.Caching.Core
         private ConcurrentDictionary<string, string> cacheNotifierAssociations
             = new ConcurrentDictionary<string, string>();
 
+        /// <summary>
+        /// The source to load the cache configuration from
+        /// OPTIONAL: if null then no cache configuration will be loaded
+        /// </summary>
         public ICacheConfigLoader ConfigLoader { get; private set; }
 
+        /// <summary>
+        /// The CTOR to set up the initial configLoader
+        /// OPTIONAL: if null then no cache configuration will be loaded
+        /// </summary>
+        /// <param name="configLoader"></param>
         public CacheManagerLogic(ICacheConfigLoader configLoader)
         {
             ConfigLoader = configLoader;
@@ -304,15 +317,18 @@ namespace PubComp.Caching.Core
 
         /// <summary>
         /// Sets named cached according to set config loader
-        /// Initialization cab be overriden using SetCache and RemoveCache (and this method)
+        /// Initialization can be overriden using SetCache and RemoveCache (and this method)
         /// </summary>
         public void InitializeFromConfig()
         {
-            var config = ConfigLoader.LoadConfig();
             RemoveAllCaches();
             RemoveAllNotifiers();
             RemoveAllConnectionStrings();
-            ApplyConfig(config);
+            if (ConfigLoader != null)
+            {
+                var config = ConfigLoader.LoadConfig();
+                ApplyConfig(config);
+            }
         }
 
         /// <summary>

--- a/Core/CacheManagerLogic.cs
+++ b/Core/CacheManagerLogic.cs
@@ -1,0 +1,620 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using PubComp.Caching.Core.Config;
+using PubComp.Caching.Core.Config.Loaders;
+using PubComp.Caching.Core.Notifications;
+
+namespace PubComp.Caching.Core
+{
+    // TODO: Add XML comments
+    public class CacheManagerLogic
+    {
+        private Func<MethodBase> callingMethodGetter;
+
+        //ReSharper disable once InconsistentNaming
+        private static readonly SemaphoreSlim cachesSync
+            = new SemaphoreSlim(1, 1);
+
+        // ReSharper disable once InconsistentNaming
+        private ConcurrentDictionary<CacheName, ICache> caches
+            = new ConcurrentDictionary<CacheName, ICache>();
+
+        // ReSharper disable once InconsistentNaming
+        private static readonly ReaderWriterLockSlim notifiersSync
+            = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
+
+        // ReSharper disable once InconsistentNaming
+        private ConcurrentDictionary<string, ICacheNotifier> notifiers
+            = new ConcurrentDictionary<string, ICacheNotifier>();
+
+        // ReSharper disable once InconsistentNaming
+        private static readonly ReaderWriterLockSlim connectionStringsSync
+            = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
+
+        // ReSharper disable once InconsistentNaming
+        private ConcurrentDictionary<string, ICacheConnectionString> connectionStrings
+            = new ConcurrentDictionary<string, ICacheConnectionString>();
+
+        // ReSharper disable once InconsistentNaming
+        private ConcurrentDictionary<string, string> cacheNotifierAssociations
+            = new ConcurrentDictionary<string, string>();
+
+        public ICacheConfigLoader ConfigLoader { get; private set; } = new SystemConfigurationManagerCacheConfigLoader();
+
+        public CacheManagerLogic(ICacheConfigLoader configLoader)
+        {
+            ConfigLoader = configLoader;
+        }
+
+        #region Cache access API
+
+        /// <summary>Gets a cache instance using full name of calling method's class</summary>
+        /// <remarks>For better performance, store the result in client class</remarks>
+        public ICache GetCurrentClassCache()
+        {
+            var method = GetCallingMethod();
+            var declaringType = method.DeclaringType;
+            return GetCache(declaringType);
+        }
+
+        /// <summary>Gets a cache instance using full name of given class</summary>
+        /// <remarks>For better performance, store the result in client class</remarks>
+        public ICache GetCache<TClass>()
+        {
+            return GetCache(typeof(TClass));
+        }
+
+        /// <summary>Gets a cache instance using full name of given class</summary>
+        /// <remarks>For better performance, store the result in client class</remarks>
+        public ICache GetCache(Type type)
+        {
+            return GetCache(type.FullName);
+        }
+
+        /// <summary>Gets a list of all cache names</summary>
+        /// <remarks>For better performance, store the result in client class</remarks>
+        public IEnumerable<string> GetCacheNames()
+        {
+            string[] names;
+
+            cachesSync.Wait();
+            try
+            {
+                names = caches.Values.Select(v => v.Name).ToArray();
+            }
+            finally
+            {
+                cachesSync.Release();
+            }
+
+            return names;
+        }
+
+        /// <summary>Gets a cache by name</summary>
+        /// <remarks>For better performance, store the result in client class</remarks>
+        public ICache GetCache(string name)
+        {
+            if (name == null)
+                throw new ArgumentNullException(nameof(name));
+
+            var cachesArray = GetCaches();
+            
+            var cachesSorted = cachesArray.OrderByDescending(c => c.Key.GetMatchLevel(name));
+            var cache = cachesSorted.FirstOrDefault();
+
+            return (cache.Key.Prefix != null && cache.Key.GetMatchLevel(name) >= cache.Key.Prefix.Length) ? cache.Value : null;
+        }
+
+        /// <summary>Gets a cache by name</summary>
+        /// <remarks>For better performance, store the result in client class</remarks>
+        public async Task<ICache> GetCacheAsync(string name)
+        {
+            if (name == null)
+                throw new ArgumentNullException(nameof(name));
+
+            var cachesArray = await GetCachesAsync().ConfigureAwait(false);
+            
+            var cachesSorted = cachesArray.OrderByDescending(c => c.Key.GetMatchLevel(name));
+            var cache = cachesSorted.FirstOrDefault();
+
+            return (cache.Key.Prefix != null && cache.Key.GetMatchLevel(name) >= cache.Key.Prefix.Length) ? cache.Value : null;
+        }
+
+        /// <summary>Gets a cache by name - return a specialized cache implementation type</summary>
+        /// <remarks>For better performance, store the result in client class</remarks>
+        public TCache GetCache<TCache>(string name) where TCache : ICache
+        {
+            var cache = GetCache(name);
+            if (!(cache is TCache))
+                throw new ArgumentException("The specified cache is not of type " + typeof(TCache));
+
+            return (TCache)cache;
+        }
+
+        /// <summary>Gets a list of all notifier names</summary>
+        /// <remarks>For better performance, store the result in client class</remarks>
+        public IEnumerable<string> GetNotifierNames()
+        {
+            string[] names;
+
+            notifiersSync.EnterReadLock();
+            try
+            {
+                names = notifiers.Values.Select(v => v.Name).ToArray();
+            }
+            finally
+            {
+                notifiersSync.ExitReadLock();
+            }
+
+            return names;
+        }
+
+        /// <summary>Gets a notifier by name</summary>
+        /// <remarks>For better performance, store the result in client class</remarks>
+        public ICacheNotifier GetNotifier(string name)
+        {
+            if (name == null)
+                throw new ArgumentNullException(nameof(name));
+
+            ICacheNotifier result;
+
+            notifiersSync.EnterReadLock();
+            try
+            {
+                notifiers.TryGetValue(name, out result);
+            }
+            finally
+            {
+                notifiersSync.ExitReadLock();
+            }
+
+            return result;
+        }
+
+        /// <summary>Gets a list of all connection string names</summary>
+        /// <remarks>For better performance, store the result in client class</remarks>
+        public IEnumerable<string> GetConnectionStringNames()
+        {
+            string[] names;
+
+            connectionStringsSync.EnterReadLock();
+            try
+            {
+                names = connectionStrings.Values.Select(v => v.Name).ToArray();
+            }
+            finally
+            {
+                connectionStringsSync.ExitReadLock();
+            }
+
+            return names;
+        }
+
+        /// <summary>Gets a connection string by name</summary>
+        /// <remarks>For better performance, store the result in client class</remarks>
+        public ICacheConnectionString GetConnectionString(string name)
+        {
+            if (name == null)
+                throw new ArgumentNullException(nameof(name));
+
+            ICacheConnectionString result;
+
+            connectionStringsSync.EnterReadLock();
+            try
+            {
+                connectionStrings.TryGetValue(name, out result);
+            }
+            finally
+            {
+                connectionStringsSync.ExitReadLock();
+            }
+
+            return result;
+        }
+
+        /// <summary>Associates a cache with a notifier</summary>
+        /// <param name="cache"></param>
+        /// <param name="notifier"></param>
+        public void Associate(ICache cache, ICacheNotifier notifier)
+        {
+            cacheNotifierAssociations.AddOrUpdate(
+                cache.Name, c => notifier.Name, (c, n) => notifier.Name);
+        }
+
+        /// <summary>Gets the notifier that was associated with a cahe</summary>
+        /// <param name="cache"></param>
+        /// <returns></returns>
+        public ICacheNotifier GetAssociatedNotifier(ICache cache)
+        {
+            return cacheNotifierAssociations.TryGetValue(cache.Name, out string notifierName)
+                ? GetNotifier(notifierName)
+                : null;
+        }
+
+        #endregion
+
+        private KeyValuePair<CacheName, ICache>[] GetCaches()
+        {
+            KeyValuePair<CacheName, ICache>[] cachesArray;
+
+            cachesSync.Wait();
+            try
+            {
+                cachesArray = caches.ToArray();
+            }
+            finally
+            {
+                cachesSync.Release();
+            }
+
+            return cachesArray;
+        }
+
+        private async Task<KeyValuePair<CacheName, ICache>[]> GetCachesAsync()
+        {
+            KeyValuePair<CacheName, ICache>[] cachesArray;
+
+            await cachesSync.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                cachesArray = caches.ToArray();
+            }
+            finally
+            {
+                cachesSync.Release();
+            }
+
+            return cachesArray;
+        }
+
+        private void SyncSet(ReaderWriterLockSlim syncObj, Action action)
+        {
+            syncObj.EnterWriteLock();
+            try
+            {
+                action();
+            }
+            finally
+            {
+                syncObj.ExitWriteLock();
+            }
+        }
+
+        private void SyncSet(SemaphoreSlim syncObj, Action action)
+        {
+            syncObj.Wait();
+            try
+            {
+                action();
+            }
+            finally
+            {
+                syncObj.Release();
+            }
+        }
+
+        #region Cache configuration API
+
+        /// <summary>
+        /// Sets named cached according to set config loader
+        /// Initialization cab be overriden using SetCache and RemoveCache (and this method)
+        /// </summary>
+        public void InitializeFromConfig()
+        {
+            var config = ConfigLoader.LoadConfig();
+            RemoveAllCaches();
+            RemoveAllNotifiers();
+            RemoveAllConnectionStrings();
+            ApplyConfig(config);
+        }
+
+        /// <summary>
+        /// Adds or sets a cache by name
+        /// This method is to be used during application initialization, it does not delete or replace the cache if already in use!
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="cache"></param>
+        /// <remarks>Cache name can end with wildcard '*'</remarks>
+        public void SetCache(string name, ICache cache)
+        {
+            var cacheName = new CacheName(name);
+
+            void Action()
+            {
+                if (cache == null)
+                {
+                    // ReSharper disable once UnusedVariable
+                    caches.TryRemove(cacheName, out var oldValue);
+                }
+                else
+                {
+                    caches.AddOrUpdate(cacheName, cache, (k, v) => cache);
+                }
+            }
+
+            SyncSet(cachesSync, Action);
+        }
+
+        /// <summary>
+        /// Removes a cache registration with a given name.
+        /// This method is to be used during application initialization, it does not delete or replace the cache if already in use!
+        /// </summary>
+        /// <param name="name"></param>
+        public void RemoveCache(string name)
+        {
+            var cacheName = new CacheName(name);
+
+            void Action()
+            {
+                // ReSharper disable once UnusedVariable
+                caches.TryRemove(cacheName, out var oldValue);
+            }
+
+            SyncSet(cachesSync, Action);
+        }
+
+        /// <summary>
+        /// Removes all cache registrations with any given name.
+        /// This method is to be used during application initialization, it does not delete or replace the cache if already in use!
+        /// </summary>
+        public void RemoveAllCaches()
+        {
+            void Action()
+            {
+                caches.Clear();
+            }
+
+            SyncSet(cachesSync, Action);
+        }
+
+        /// <summary>
+        /// Adds or sets a cache by name
+        /// This method is to be used during application initialization, it does not delete or replace the cache if already in use!
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="connectionString"></param>
+        /// <remarks>Cache name can end with wildcard '*'</remarks>
+        public void SetConnectionString(string name, ICacheConnectionString connectionString)
+        {
+            void Action()
+            {
+                if (connectionString == null)
+                {
+                    // ReSharper disable once UnusedVariable
+                    connectionStrings.TryRemove(name, out var oldValue);
+                }
+                else
+                {
+                    connectionStrings.AddOrUpdate(name, connectionString, (k, v) => connectionString);
+                }
+            }
+
+            SyncSet(connectionStringsSync, Action);
+        }
+
+        /// <summary>
+        /// Removes a cache registration with a given name.
+        /// This method is to be used during application initialization, it does not delete or replace the cache if already in use!
+        /// </summary>
+        /// <param name="name"></param>
+        public void RemoveConnectionString(string name)
+        {
+            void Action()
+            {
+                // ReSharper disable once UnusedVariable
+                connectionStrings.TryRemove(name, out var oldValue);
+            }
+
+            SyncSet(connectionStringsSync, Action);
+        }
+
+        /// <summary>
+        /// Removes all cache registrations with any given name.
+        /// This method is to be used during application initialization, it does not delete or replace the cache if already in use!
+        /// </summary>
+        public void RemoveAllConnectionStrings()
+        {
+            void Action()
+            {
+                connectionStrings.Clear();
+            }
+
+            SyncSet(connectionStringsSync, Action);
+        }
+
+        /// <summary>
+        /// Adds or sets a notifier by name
+        /// This method is to be used during application initialization, it does not delete or replace the notifier if already in use!
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="notifier"></param>
+        public void SetNotifier(string name, ICacheNotifier notifier)
+        {
+            void Action()
+            {
+                if (notifier == null)
+                {
+                    // ReSharper disable once UnusedVariable
+                    notifiers.TryRemove(name, out var oldValue);
+                }
+                else
+                {
+                    notifiers.AddOrUpdate(name, notifier, (k, v) => notifier);
+                }
+            }
+
+            SyncSet(notifiersSync, Action);
+        }
+
+        /// <summary>
+        /// Removes a notifier registration with a given name.
+        /// This method is to be used during application initialization, it does not delete or replace the notifier if already in use!
+        /// </summary>
+        /// <param name="name"></param>
+        public void RemoveNotifier(string name)
+        {
+            void Action()
+            {
+                // ReSharper disable once UnusedVariable
+                notifiers.TryRemove(name, out var oldValue);
+            }
+
+            SyncSet(notifiersSync, Action);
+        }
+
+        /// <summary>
+        /// Removes all notifier registrations with any given name.
+        /// This method is to be used during application initialization, it does not delete or replace the notifier if already in use!
+        /// </summary>
+        public void RemoveAllNotifiers()
+        {
+            void Action()
+            {
+                notifiers.Clear();
+            }
+
+            SyncSet(notifiersSync, Action);
+        }
+
+        #endregion
+
+        #region Automatic cache naming
+
+        // ReSharper disable once InconsistentNaming
+        private static readonly object loadLock = new object();
+
+        private MethodBase GetCallingMethod()
+        {
+            Func<MethodBase> method = callingMethodGetter;
+            if (method == null)
+            {
+                lock (loadLock)
+                {
+                    if (callingMethodGetter == null)
+                        callingMethodGetter = CreateGetClassNameFunction();
+
+                    method = callingMethodGetter;
+                }
+            }
+            return method();
+        }
+
+        private Func<MethodBase> CreateGetClassNameFunction()
+        {
+            var stackFrameType = Type.GetType("System.Diagnostics.StackFrame");
+            if (stackFrameType == null)
+                throw new PlatformNotSupportedException("CreateGetClassNameFunction is only supported on platforms where System.Diagnostics.StackFrame exist");
+
+            var constructor = stackFrameType.GetConstructor(new[] { typeof(int) });
+            var getMethodMethod = stackFrameType.GetMethod("GetMethod");
+
+            if (constructor == null)
+                throw new PlatformNotSupportedException("StackFrame(int skipFrames) constructor not present");
+            
+            if (getMethodMethod == null)
+                throw new PlatformNotSupportedException("StackFrame.GetMethod() not present");
+
+            var stackFrame = Expression.New(constructor, Expression.Constant(4));
+            var method = Expression.Call(stackFrame, getMethodMethod);
+            var lambda = Expression.Lambda<Func<MethodBase>>(method);
+            var compileFunction = lambda.GetType().GetMethod("Compile", new Type[0]);
+            var function = (Func<MethodBase>)compileFunction.Invoke(lambda, null);
+
+            return function;
+        }
+
+        #endregion
+
+        #region Config Loading
+
+        //private static IList<ConfigNode> LoadConfig()
+        //{
+        //    var config = ConfigurationManager.GetSection("PubComp/CacheConfig") as IList<ConfigNode>;
+        //    return config;
+        //}
+
+        private void ApplyConfig(IList<ConfigNode> config)
+        {
+            if (config == null)
+                return;
+
+            var connectionConfigs = new List<ConnectionStringConfig>();
+            var notifierConfigs = new List<NotifierConfig>();
+            var cacheConfigs = new List<CacheConfig>();
+            var connectionRemoveIndexes = new List<int>();
+            var notifierRemoveIndexes = new List<int>();
+            var cacheRemoveIndexes = new List<int>();
+
+            foreach (var item in config)
+            {
+                switch (item.Action)
+                {
+                    case ConfigAction.Remove:
+                        // Remove existing nodes
+                        RemoveCache(item.Name);
+                        RemoveNotifier(item.Name);
+                        RemoveConnectionString(item.Name);
+
+                        // Save which pending nodes to remove
+                        connectionRemoveIndexes.AddRange(
+                            connectionConfigs.Select((cfg, index) => Tuple.Create(index, cfg))
+                                .Where(c => c.Item2.Name == item.Name).Select(c => c.Item1).Reverse());
+                        notifierRemoveIndexes.AddRange(
+                            notifierConfigs.Select((cfg, index) => Tuple.Create(index, cfg))
+                                .Where(c => c.Item2.Name == item.Name).Select(c => c.Item1).Reverse());
+                        cacheRemoveIndexes.AddRange(
+                            cacheConfigs.Select((cfg, index) => Tuple.Create(index, cfg))
+                                .Where(c => c.Item2.Name == item.Name).Select(c => c.Item1).Reverse());
+                        break;
+
+                    case ConfigAction.Add:
+                        // Add to pending nodes
+                        if (item is CacheConfig cacheConfig)
+                        {
+                            cacheConfigs.Add(cacheConfig);
+                        }
+                        else if (item is NotifierConfig notifierConfig)
+                        {
+                            notifierConfigs.Add(notifierConfig);
+                        }
+                        else if (item is ConnectionStringConfig connectionStringConfig)
+                        {
+                            connectionConfigs.Add(connectionStringConfig);
+                        }
+                        break;
+                }
+            }
+
+            // Remove pending nodes marked for removal
+            cacheRemoveIndexes = cacheRemoveIndexes.OrderByDescending(i => i).ToList();
+            notifierRemoveIndexes = notifierRemoveIndexes.OrderByDescending(i => i).ToList();
+            connectionRemoveIndexes = connectionRemoveIndexes.OrderByDescending(i => i).ToList();
+            foreach (var i in cacheRemoveIndexes)
+                cacheConfigs.RemoveAt(i);
+            foreach (var i in notifierRemoveIndexes)
+                notifierConfigs.RemoveAt(i);
+            foreach (var i in connectionRemoveIndexes)
+                connectionConfigs.RemoveAt(i);
+
+            // Add still pending nodes,
+            // order by types (to enable forward declaration)
+            // and then by appearance in config
+            // TODO: Pass ICacheManager or subset to the Create*() that call CacheManager directly
+            foreach (var item in connectionConfigs)
+                SetConnectionString(item.Name, item.CreateConnectionString());
+            foreach (var item in notifierConfigs)
+                SetNotifier(item.Name, item.CreateCacheNotifier());
+            foreach (var item in cacheConfigs)
+                SetCache(item.Name, item.CreateCache());
+        }
+
+        #endregion
+    }
+}

--- a/Core/CacheManagerSettings.cs
+++ b/Core/CacheManagerSettings.cs
@@ -1,0 +1,23 @@
+﻿using PubComp.Caching.Core.Config.Loaders;
+
+namespace PubComp.Caching.Core
+{
+    /// <summary>
+    /// Initialization time settings for the Cache Manager
+    /// </summary>
+    public class CacheManagerSettings
+    {
+        /// <summary>
+        /// The source from which the entire cache configuration will be loaded from.
+        /// The default value is to use System.ConfigurationManager internally to load from app/web.config
+        /// This setting should be set before any call to the API methods
+        /// </summary>
+        public ICacheConfigLoader ConfigLoader { get; set; }
+
+        /// <summary>
+        /// If set to true, after CacheManager initialization done
+        /// all the cache names will be automatically registered with CacheControllerUtil.
+        /// </summary>
+        public bool ShouldRegisterAllCaches { get; set; }
+    }
+}

--- a/Core/Config/Loaders/CacheConfigLoadErrorsException.cs
+++ b/Core/Config/Loaders/CacheConfigLoadErrorsException.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PubComp.Caching.Core.Config.Loaders
+{
+    public class CacheConfigLoadErrorsException : ApplicationException
+    {
+        public override string Message => string.Join(Environment.NewLine, errors);
+
+        private readonly List<CacheConfigLoadError> errors;
+        public CacheConfigLoadErrorsException()
+        {
+            errors = new List<CacheConfigLoadError>();
+        }
+
+        public void Add(CacheConfigLoadError cacheConfigLoadError)
+        {
+            errors.Add(cacheConfigLoadError);
+        }
+
+        public bool IsEmpty() => errors.Count == 0;
+
+        public class CacheConfigLoadError
+        {
+            public string Error { get; set; }
+            public Exception Exception { get; set; } = null;
+
+            public override string ToString()
+            {
+                if (Exception != null)
+                {
+                    return $"Error:{Error} Exception:{Exception.Message}";
+                }
+
+                return $"Error:{Error}";
+            }
+        }
+    }
+}

--- a/Core/Config/Loaders/ICacheConfigLoader.cs
+++ b/Core/Config/Loaders/ICacheConfigLoader.cs
@@ -2,9 +2,15 @@
 
 namespace PubComp.Caching.Core.Config.Loaders
 {
-    // TODO: Add XML comments
+    /// <summary>
+    /// The interface provides a load method and should be used to load the cache configuration from different sources 
+    /// </summary>
     public interface ICacheConfigLoader
     {
+        /// <summary>
+        /// Load the configuration data from the source and return it as an ordered list of relevant ConfigNode types
+        /// </summary>
+        /// <returns>The list of Cache ConfigNode (and its inheriting classes)</returns>
         IList<ConfigNode> LoadConfig();
     }
 }

--- a/Core/Config/Loaders/ICacheConfigLoader.cs
+++ b/Core/Config/Loaders/ICacheConfigLoader.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace PubComp.Caching.Core.Config.Loaders
+{
+    // TODO: Add XML comments
+    public interface ICacheConfigLoader
+    {
+        IList<ConfigNode> LoadConfig();
+    }
+}

--- a/Core/Config/Loaders/MicrosoftExtensionsCacheConfigLoader.cs
+++ b/Core/Config/Loaders/MicrosoftExtensionsCacheConfigLoader.cs
@@ -7,11 +7,12 @@ using System.Reflection;
 namespace PubComp.Caching.Core.Config.Loaders
 {
     /// <summary>
-    /// Load the cache configuration using .NetStandard's Microsoft.Extenstions.Configuration
+    /// Load the cache configuration using .NetStandard's Microsoft.Extensions.Configuration
     /// </summary>
     public class MicrosoftExtensionsCacheConfigLoader : ICacheConfigLoader
     {
         private readonly IConfigurationSection pubCompCacheConfigurationSection;
+        private readonly CacheConfigLoadErrorsException cacheConfigLoadErrorsException = new CacheConfigLoadErrorsException();
 
         public MicrosoftExtensionsCacheConfigLoader(IConfigurationSection pubCompCacheConfigurationSection)
         {
@@ -85,6 +86,9 @@ namespace PubComp.Caching.Core.Config.Loaders
                 configNodes.Add(configNode);
             }
 
+            if (!cacheConfigLoadErrorsException.IsEmpty())
+                throw cacheConfigLoadErrorsException;
+
             return configNodes;
         }
 
@@ -101,6 +105,9 @@ namespace PubComp.Caching.Core.Config.Loaders
                 System.Diagnostics.Debug.WriteLine(
                     $"{typeof(MicrosoftExtensionsCacheConfigLoader).FullName}: {error}");
             }
+
+            cacheConfigLoadErrorsException.Add(new CacheConfigLoadErrorsException.CacheConfigLoadError
+                {Error = error, Exception = ex});
         }
     }
 }

--- a/Core/Config/Loaders/MicrosoftExtensionsCacheConfigLoader.cs
+++ b/Core/Config/Loaders/MicrosoftExtensionsCacheConfigLoader.cs
@@ -12,6 +12,8 @@ namespace PubComp.Caching.Core.Config.Loaders
     public class MicrosoftExtensionsCacheConfigLoader : ICacheConfigLoader
     {
         private readonly IConfigurationSection pubCompCacheConfigurationSection;
+
+        // TODO: move this to a local variable
         private CacheConfigLoadErrorsException cacheConfigLoadErrorsException;
 
         public MicrosoftExtensionsCacheConfigLoader(IConfigurationSection pubCompCacheConfigurationSection)

--- a/Core/Config/Loaders/MicrosoftExtensionsCacheConfigLoader.cs
+++ b/Core/Config/Loaders/MicrosoftExtensionsCacheConfigLoader.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using System.Linq;
+using System.Reflection;
+
+namespace PubComp.Caching.Core.Config.Loaders
+{
+    // TODO: Add XML comments
+    public class MicrosoftExtensionsCacheConfigLoader : ICacheConfigLoader
+    {
+        private readonly IConfigurationSection pubCompCacheConfigurationSection;
+
+        public MicrosoftExtensionsCacheConfigLoader(IConfigurationSection pubCompCacheConfigurationSection)
+        {
+            this.pubCompCacheConfigurationSection = pubCompCacheConfigurationSection;
+        }
+
+        public MicrosoftExtensionsCacheConfigLoader(IConfiguration pubCompCacheConfiguration)
+        : this(pubCompCacheConfiguration.GetSection("PubComp:CacheConfig"))
+        {
+        }
+        public IList<ConfigNode> LoadConfig()
+        {
+            var configNodes = new List<ConfigNode>();
+            var cacheConfigs =
+                pubCompCacheConfigurationSection
+                    .GetChildren();
+
+            foreach (var cacheConfig in cacheConfigs)
+            {
+                if (cacheConfig.GetValue<ConfigAction>("action") == ConfigAction.Remove)
+                {
+                    configNodes.Add(new RemoveConfig { Action = ConfigAction.Remove, Name = cacheConfig["name"] });
+                    continue;
+                }
+
+                var typeName = cacheConfig["type"] + "Config";
+                var assemblyName = cacheConfig["assembly"];
+                Assembly assembly;
+
+                try
+                {
+                    // TODO: Reusage of Assemblies
+                    assembly = Assembly.Load(assemblyName);
+                }
+                catch (System.IO.FileLoadException ex)
+                {
+                    LogConfigError($"Could not load assembly {assemblyName}", ex);
+                    continue;
+                }
+                catch (BadImageFormatException ex)
+                {
+                    LogConfigError($"Could not load assembly {assemblyName}", ex);
+                    continue;
+                }
+
+                var configType = assembly.GetType(typeName, false, false);
+                if (configType == null)
+                {
+                    configType = assembly.GetType(assemblyName + '.' + typeName, false, false);
+                }
+
+                if (configType == null)
+                {
+                    LogConfigError($"Could not load type {typeName} from assembly {assemblyName}");
+                    continue;
+                }
+
+                configNodes.Add(cacheConfig.Get(configType) as ConfigNode);
+            }
+
+            return configNodes;
+        }
+
+        private void LogConfigError(string error, Exception ex = null)
+        {
+            if (ex != null)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"{typeof(MicrosoftExtensionsCacheConfigLoader).FullName}: {error}. Exception: {ex}");
+            }
+            else
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"{typeof(MicrosoftExtensionsCacheConfigLoader).FullName}: {error}");
+            }
+        }
+    }
+}

--- a/Core/Config/Loaders/MicrosoftExtensionsCacheConfigLoader.cs
+++ b/Core/Config/Loaders/MicrosoftExtensionsCacheConfigLoader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.Extensions.Configuration;
 using System.Reflection;
 
@@ -59,12 +60,9 @@ namespace PubComp.Caching.Core.Config.Loaders
                     {
                         assembly = Assembly.Load(assemblyName);
                     }
-                    catch (System.IO.FileLoadException ex)
-                    {
-                        LogConfigError($"Could not load assembly {assemblyName}", ex);
-                        continue;
-                    }
-                    catch (BadImageFormatException ex)
+                    catch (Exception ex) when (ex is FileLoadException ||
+                                               ex is FileNotFoundException ||
+                                               ex is BadImageFormatException)
                     {
                         LogConfigError($"Could not load assembly {assemblyName}", ex);
                         continue;

--- a/Core/Config/Loaders/MicrosoftExtensionsCacheConfigLoader.cs
+++ b/Core/Config/Loaders/MicrosoftExtensionsCacheConfigLoader.cs
@@ -12,7 +12,7 @@ namespace PubComp.Caching.Core.Config.Loaders
     public class MicrosoftExtensionsCacheConfigLoader : ICacheConfigLoader
     {
         private readonly IConfigurationSection pubCompCacheConfigurationSection;
-        private readonly CacheConfigLoadErrorsException cacheConfigLoadErrorsException = new CacheConfigLoadErrorsException();
+        private CacheConfigLoadErrorsException cacheConfigLoadErrorsException;
 
         public MicrosoftExtensionsCacheConfigLoader(IConfigurationSection pubCompCacheConfigurationSection)
         {
@@ -37,6 +37,7 @@ namespace PubComp.Caching.Core.Config.Loaders
         /// <returns>The list of Cache ConfigNode (and its inheriting classes)</returns>
         public IList<ConfigNode> LoadConfig()
         {
+            cacheConfigLoadErrorsException = new CacheConfigLoadErrorsException();
             var assemblies = new Dictionary<string, Assembly>();
             var configNodes = new List<ConfigNode>();
             var cacheConfigs = pubCompCacheConfigurationSection.GetChildren();
@@ -59,7 +60,7 @@ namespace PubComp.Caching.Core.Config.Loaders
                         assembly = Assembly.Load(assemblyName);
                     }
                     catch (Exception ex) when (ex is FileLoadException ||
-                                               ex is FileNotFoundException || // Was FileNotFoundException missing on purpose?
+                                               ex is FileNotFoundException ||
                                                ex is BadImageFormatException)
                     {
                         LogConfigError($"Could not load assembly {assemblyName}", ex);

--- a/Core/Config/Loaders/SystemConfigurationManagerCacheConfigLoader.cs
+++ b/Core/Config/Loaders/SystemConfigurationManagerCacheConfigLoader.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Configuration;
+
+namespace PubComp.Caching.Core.Config.Loaders
+{
+    // TODO: Add XML comments
+    public class SystemConfigurationManagerCacheConfigLoader : ICacheConfigLoader
+    {
+        public IList<ConfigNode> LoadConfig()
+        {
+            return ConfigurationManager.GetSection("PubComp/CacheConfig") as IList<ConfigNode>;
+        }
+    }
+}

--- a/Core/Config/Loaders/SystemConfigurationManagerCacheConfigLoader.cs
+++ b/Core/Config/Loaders/SystemConfigurationManagerCacheConfigLoader.cs
@@ -4,7 +4,7 @@ using System.Configuration;
 namespace PubComp.Caching.Core.Config.Loaders
 {
     /// <summary>
-    /// Load the cache configuration using App/Web.config files (System.ConfigurationManager)
+    /// Load the cache configuration using App/Web.config files using <see cref="System.Configuration.ConfigurationManager" />
     /// </summary>
     public class SystemConfigurationManagerCacheConfigLoader : ICacheConfigLoader
     {

--- a/Core/Config/Loaders/SystemConfigurationManagerCacheConfigLoader.cs
+++ b/Core/Config/Loaders/SystemConfigurationManagerCacheConfigLoader.cs
@@ -3,7 +3,9 @@ using System.Configuration;
 
 namespace PubComp.Caching.Core.Config.Loaders
 {
-    // TODO: Add XML comments
+    /// <summary>
+    /// Load the cache configuration using App/Web.config files (System.ConfigurationManager)
+    /// </summary>
     public class SystemConfigurationManagerCacheConfigLoader : ICacheConfigLoader
     {
         public IList<ConfigNode> LoadConfig()

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -9,6 +9,7 @@
     <FileVersion>4.1.1.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
Required to split all the singleton (+static ctor) logic, in order to have init time settings possible to change the behavior of the CacheManager.