### PR TITLE
New Invalidation Features and reduction in Redis Connections made

### DIFF
--- a/Core.UnitTests/Mocks/NoNotifier.cs
+++ b/Core.UnitTests/Mocks/NoNotifier.cs
@@ -6,13 +6,16 @@ namespace PubComp.Caching.Core.UnitTests.Mocks
     public class NoNotifier : ICacheNotifier
     {
         private readonly string name;
-
+        private readonly NoNotifierPolicy policy;
         // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
         private readonly string connectionString;
+
+        public bool IsInvalidateOnUpdateEnabled { get { return policy.InvalidateOnUpdate; } }
 
         public NoNotifier(string name, NoNotifierPolicy policy)
         {
             this.name = name;
+            this.policy = policy;
 
             if (policy == null)
                 throw new ArgumentNullException(nameof(policy));
@@ -44,8 +47,20 @@ namespace PubComp.Caching.Core.UnitTests.Mocks
         {
         }
 
+        public void Subscribe(string cacheName, 
+            Func<CacheItemNotification, bool> cacheUpdatedCallback,
+            EventHandler<Core.Events.ProviderStateChangedEventArgs> notifierProviderStateChangedCallback)
+        {
+        }
+
+
         public void UnSubscribe(string cacheName)
         {
+        }
+
+        public bool TryPublish(string cacheName, string key, CacheItemActionTypes action)
+        {
+            return true;
         }
 
         public void Publish(string cacheName, string key, CacheItemActionTypes action)

--- a/Core.UnitTests/Mocks/NoNotifierPolicy.cs
+++ b/Core.UnitTests/Mocks/NoNotifierPolicy.cs
@@ -11,5 +11,10 @@
         /// Connection string name. You must either fill this in or ConnectionString.
         /// </summary>
         public string ConnectionName { get; set; }
+
+        /// <summary>
+        /// Optional - Automatic publish CacheItemActionTypes.Updated when overriding cache item with new value
+        /// </summary>
+        public bool InvalidateOnUpdate { get; set; }
     }
 }

--- a/Core/Events/ProviderStateChangedEventArgs.cs
+++ b/Core/Events/ProviderStateChangedEventArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace PubComp.Caching.Core.Events
+{
+    public class ProviderStateChangedEventArgs : EventArgs
+    {
+        public bool NewState { get; }
+
+        public ProviderStateChangedEventArgs(bool newState)
+        {
+            NewState = newState;
+        }
+    }
+}

--- a/Core/Notifications/ICacheNotifier.cs
+++ b/Core/Notifications/ICacheNotifier.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using PubComp.Caching.Core.Events;
+using System;
 
 namespace PubComp.Caching.Core.Notifications
 {
@@ -6,10 +7,15 @@ namespace PubComp.Caching.Core.Notifications
     {
         string Name { get; }
 
+        bool IsInvalidateOnUpdateEnabled { get; }
+
         void Subscribe(string cacheName, Func<CacheItemNotification, bool> callback);
+
+        void Subscribe(string cacheName, Func<CacheItemNotification, bool> cacheUpdatedCallback, EventHandler<ProviderStateChangedEventArgs> notifierProviderStateChangedCallback);
 
         void UnSubscribe(string cacheName);
 
         void Publish(string cacheName, string key, CacheItemActionTypes action);
+        bool TryPublish(string cacheName, string key, CacheItemActionTypes action);
     }
 }

--- a/DemoSynchronizedClient/App.config
+++ b/DemoSynchronizedClient/App.config
@@ -9,9 +9,11 @@
 
   <PubComp>
     <CacheConfig>
-      <add name="redisNotifier" assembly="PubComp.Caching.RedisCaching" type="RedisCacheNotifier" policy="{'ConnectionName':'localRedis'}" />
       <add name="localRedis" assembly="PubComp.Caching.RedisCaching" type="RedisConnectionString" connectionString="127.0.0.1:6379,serviceName=mymaster" />
+      <add name="redisNotifier" assembly="PubComp.Caching.RedisCaching" type="RedisCacheNotifier" policy="{'ConnectionName':'localRedis'}" />
+      <add name="redisNotifierWithAutomaticInvalidation" assembly="PubComp.Caching.RedisCaching" type="RedisCacheNotifier" policy="{'ConnectionName':'localRedis', 'InvalidateOnUpdate':true}" />
       <add name="MyApp.LocalCacheWithNotifier" assembly="PubComp.Caching.SystemRuntime" type="InMemoryCache" policy="{'ExpirationFromAdd':'01:00:00', 'SyncProvider':'redisNotifier'}" />
+      <add name="MyApp.LocalCacheWithNotifierAndAutomaticInvalidationOnUpdate" assembly="PubComp.Caching.SystemRuntime" type="InMemoryCache" policy="{'ExpirationFromAdd':'01:00:00', 'SyncProvider':'redisNotifierWithAutomaticInvalidation'}" />
     </CacheConfig>
   </PubComp>
 

--- a/RedisCaching.UnitTests/App.config
+++ b/RedisCaching.UnitTests/App.config
@@ -12,12 +12,19 @@
       <add name="redisCache" assembly="PubComp.Caching.RedisCaching" type="RedisCache" policy="{'ConnectionName':'localRedisAdmin', 'ExpirationFromAdd':'00:10:00'}" />
       <add name="localCache" assembly="PubComp.Caching.SystemRuntime" type="InMemoryCache" policy="{'ExpirationFromAdd':'00:10:00', 'SyncProvider':'redisNotifier'}" />
       <add name="layeredCache" assembly="PubComp.Caching.Core" type="LayeredCache" policy="{'Level1CacheName':'localCache', 'Level2CacheName':'redisCache'}" />
-      <add name="redisNotifier" assembly="PubComp.Caching.RedisCaching" type="RedisCacheNotifier" policy="{'ConnectionName':'localRedis'}" />
+      <add name="redisNotifier" assembly="PubComp.Caching.RedisCaching" type="RedisCacheNotifier" policy="{'ConnectionName':'localRedis', 'GeneralInvalidationChannel':'+general-invalidation'}" />
+      <add name="redisNotifierWithAutomaticInvalidation" assembly="PubComp.Caching.RedisCaching" type="RedisCacheNotifier" policy="{'ConnectionName':'localRedis', 'InvalidateOnUpdate':true}" />
       <add name="localRedis" assembly="PubComp.Caching.RedisCaching" type="RedisConnectionString" connectionString="127.0.0.1:6379,serviceName=mymaster" />
       <add name="localRedisAdmin" assembly="PubComp.Caching.RedisCaching.UnitTests" type="Mocks.B64EncConnectionString" encConnectionString="MTI3LjAuMC4xOjYzNzksc2VydmljZU5hbWU9bXltYXN0ZXIsYWxsb3dBZG1pbj10cnVl" />
 
       <add name="MyApp.LocalCacheWithNotifier" assembly="PubComp.Caching.SystemRuntime" type="InMemoryCache" policy="{'ExpirationFromAdd':'01:00:00', 'SyncProvider':'redisNotifier'}" />
       <add name="MyApp.LocalCacheWithNotifier2" assembly="PubComp.Caching.SystemRuntime" type="InMemoryCache" policy="{'ExpirationFromAdd':'01:00:00', 'SyncProvider':'redisNotifier'}" />
+      <add name="MyApp.LocalCacheWithNotifierAndAutomaticInvalidationOnUpdate" assembly="PubComp.Caching.SystemRuntime" type="InMemoryCache" policy="{'ExpirationFromAdd':'01:00:00', 'SyncProvider':'redisNotifierWithAutomaticInvalidation'}" />
+
+      <add name="MyApp.LocalCacheWithNotifierAndFallback" assembly="PubComp.Caching.SystemRuntime" type="InMemoryCache" policy="{'ExpirationFromAdd':'01:00:00', 'SyncProvider':'redisNotifier', 'OnSyncProviderFailure':{'ExpirationFromAdd':'00:00:03'}}" />
+      <add name="invalidConnectionRedis" assembly="PubComp.Caching.RedisCaching" type="RedisConnectionString" connectionString="127.0.0.1:7379,serviceName=mymaster" />
+      <add name="invalidConnectionRedisNotifier" assembly="PubComp.Caching.RedisCaching" type="RedisCacheNotifier" policy="{'ConnectionName':'invalidConnectionRedis'}" />
+      <add name="MyApp.LocalCacheWithNotifierAndFallbackInvalidConnection" assembly="PubComp.Caching.SystemRuntime" type="InMemoryCache" policy="{'ExpirationFromAdd':'01:00:00', 'SyncProvider':'invalidConnectionRedisNotifier', 'OnSyncProviderFailure':{'ExpirationFromAdd':'00:00:01'}}" />
     </CacheConfig>
   </PubComp>
   

--- a/RedisCaching/CacheContext.cs
+++ b/RedisCaching/CacheContext.cs
@@ -10,11 +10,17 @@ namespace PubComp.Caching.RedisCaching
     {
         private readonly RedisClient client;
         private readonly IRedisConverter convert;
-        
+
         public CacheContext(String connectionString, String converterType, String clusterType, int monitorPort, int monitorIntervalMilliseconds)
         {
             this.convert = RedisConverterFactory.CreateConverter(converterType);
-            this.client = new RedisClient(connectionString, clusterType, monitorPort,monitorIntervalMilliseconds);
+            this.client = new RedisClient(connectionString, clusterType, monitorPort, monitorIntervalMilliseconds);
+        }
+
+        public CacheContext(String connectionName, String converterType)
+        {
+            this.convert = RedisConverterFactory.CreateConverter(converterType);
+            this.client = RedisClient.GetNamedRedisClient(connectionName);
         }
 
         internal CacheItem<TValue> GetItem<TValue>(String cacheName, String key)

--- a/RedisCaching/RedisCache.cs
+++ b/RedisCaching/RedisCache.cs
@@ -92,8 +92,15 @@ namespace PubComp.Caching.RedisCaching
 
             this.useSlidingExpiration = (policy.SlidingExpiration < TimeSpan.MaxValue);
 
-            this.innerCache = new CacheContext(
-                this.connectionString, this.converterType, this.clusterType, this.monitorPort, this.monitorIntervalMilliseconds);
+            if (string.IsNullOrEmpty(policy.ConnectionName))
+            {
+                this.innerCache = new CacheContext(
+                    this.connectionString, this.converterType, this.clusterType, this.monitorPort, this.monitorIntervalMilliseconds);
+            }
+            else
+            {
+                this.innerCache = new CacheContext(policy.ConnectionName, this.converterType);
+            }
 
             this.notiferName = policy.SyncProvider;
 

--- a/RedisCaching/RedisClient.cs
+++ b/RedisCaching/RedisClient.cs
@@ -1,7 +1,8 @@
-﻿using System;
+﻿using StackExchange.Redis;
+using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Net;
-using StackExchange.Redis;
 
 namespace PubComp.Caching.RedisCaching
 {
@@ -11,6 +12,31 @@ namespace PubComp.Caching.RedisCaching
         private readonly NLog.ILogger log;
         private IConnectionMultiplexer innerContext;
         private IRedisMonitor redisMonitor;
+        public event EventHandler<Core.Events.ProviderStateChangedEventArgs> OnRedisConnectionStateChanged;
+
+        public static ConcurrentDictionary<string, Lazy<RedisClient>> ActiveRedisClients = new ConcurrentDictionary<string, Lazy<RedisClient>>();
+
+        public static RedisClient GetNamedRedisClient(string connectionName) => GetNamedRedisClient(connectionName, null);
+        public static RedisClient GetNamedRedisClient(string connectionName, EventHandler<Core.Events.ProviderStateChangedEventArgs> providerStateChangedCallback)
+        {
+            var lazyRedisClientCreator = new Lazy<RedisClient>(() =>
+            {
+                var redisConnectionConfig = PubComp.Caching.Core.CacheManager.GetConnectionString(connectionName);
+                var policy = (redisConnectionConfig as RedisConnectionString)?.Policy ?? new RedisClientPolicy();
+                return new RedisClient(redisConnectionConfig.ConnectionString, policy.ClusterType, policy.MonitorPort, policy.MonitorIntervalMilliseconds);
+            }, isThreadSafe: true);
+
+            var client = ActiveRedisClients.GetOrAdd(connectionName, lazyRedisClientCreator).Value;
+
+            if (providerStateChangedCallback != null)
+            {
+                client.OnRedisConnectionStateChanged += providerStateChangedCallback;
+                if (!client.IsConnected)
+                    providerStateChangedCallback(client, new Core.Events.ProviderStateChangedEventArgs(client.IsConnected));
+            }
+
+            return client;
+        }
 
         public RedisClient(String connectionString, String clusterType, int monitorPort, int monitorIntervalMilliseconds)
         {
@@ -21,12 +47,50 @@ namespace PubComp.Caching.RedisCaching
             RedisMonitor(clusterType, monitorPort, monitorIntervalMilliseconds);
         }
 
+        public bool IsConnected => this.innerContext?.IsConnected ?? false;
+
+        private bool? lastConnectionStateChangedValue = null;
+        private void InvokeConnectionStateChangedCallback(bool newState)
+        {
+            if ((lastConnectionStateChangedValue ?? !newState) == newState)
+                return;
+
+            lastConnectionStateChangedValue = newState;
+
+            try
+            {
+                OnRedisConnectionStateChanged(this, new Core.Events.ProviderStateChangedEventArgs(newState));
+            }
+            catch (Exception e)
+            {
+                log.Error(e, "Failed to invoke ConnectionStateChanged");
+            }
+        }
+
+        private void OnConnectionMultiplexerConnectivityEvent(object sender, EventArgs args)
+        {
+            InvokeConnectionStateChangedCallback(IsConnected);
+        }
+
+        public void RegisterConnectionEvents(IConnectionMultiplexer connectionMultiplexer)
+        {
+            connectionMultiplexer.ConnectionFailed += OnConnectionMultiplexerConnectivityEvent;
+            connectionMultiplexer.ConnectionRestored += OnConnectionMultiplexerConnectivityEvent;
+        }
+
+        public void DeregisterConnectionEvents(IConnectionMultiplexer connectionMultiplexer)
+        {
+            connectionMultiplexer.ConnectionFailed -= OnConnectionMultiplexerConnectivityEvent;
+            connectionMultiplexer.ConnectionRestored -= OnConnectionMultiplexerConnectivityEvent;
+        }
+
         private void RedisConnect()
         {
             try
             {
                 if (this.innerContext != null)
                 {
+                    DeregisterConnectionEvents(this.innerContext);
                     this.innerContext.Close();
                     this.innerContext.Dispose();
                     this.innerContext = null;
@@ -37,6 +101,7 @@ namespace PubComp.Caching.RedisCaching
                 log.Debug("Redis Reconnect: {0}", config.ToString(false));
                 config.AbortOnConnectFail = false;
                 this.innerContext = ConnectionMultiplexer.Connect(config);
+                RegisterConnectionEvents(this.innerContext);
             }
         }
 

--- a/RedisCaching/RedisClientPolicy.cs
+++ b/RedisCaching/RedisClientPolicy.cs
@@ -1,21 +1,11 @@
 ﻿namespace PubComp.Caching.RedisCaching
 {
-    public class RedisCacheNotifierPolicy
+    public class RedisClientPolicy
     {
         /// <summary>
         /// Connection string to Redis. You must either fill this in or ConnectionName.
         /// </summary>
         public string ConnectionString { get; set; }
-
-        /// <summary>
-        /// Connection string name. You must either fill this in or ConnectionString.
-        /// </summary>
-        public string ConnectionName { get; set; }
-
-        /// <summary>
-        /// Redic converter. Currently supports "json" (default), "bson", "deflate" or "gzip".
-        /// </summary>
-        public string Converter { get; set; }
 
         /// <summary>
         /// Redis ClusterType. Currently supports "replica" (default) or "none" (and in the future "cluster").
@@ -32,24 +22,12 @@
         /// </summary>
         public int MonitorIntervalMilliseconds { get; set; }
 
-        /// <summary>
-        /// Optional - subscribe to a general invalidation channel for cluster invalidation requests
-        /// </summary>
-        public string GeneralInvalidationChannel { get; set; }
-
-        /// <summary>
-        /// Optional - Automatic publish CacheItemActionTypes.Updated when overriding cache item with new value
-        /// </summary>
-        public bool InvalidateOnUpdate { get; set; }
-
-        public RedisCacheNotifierPolicy()
+        public RedisClientPolicy()
         {
             ConnectionString = @"127.0.0.1:6379,serviceName=mymaster";
             MonitorIntervalMilliseconds = 5000;
             ClusterType = "none";
-            Converter = "json";
             MonitorPort = 26379;
-            InvalidateOnUpdate = false;
         }
     }
 }

--- a/RedisCaching/RedisConnectionString.cs
+++ b/RedisCaching/RedisConnectionString.cs
@@ -7,10 +7,13 @@ namespace PubComp.Caching.RedisCaching
         public string Name { get; }
         public string ConnectionString { get; }
 
-        public RedisConnectionString(string name, string value)
+        public RedisClientPolicy Policy { get; set; }
+
+        public RedisConnectionString(string name, string connectionString, RedisClientPolicy policy)
         {
             this.Name = name;
-            this.ConnectionString = value;
+            this.ConnectionString = connectionString;
+            this.Policy = policy;
         }
     }
 }

--- a/RedisCaching/RedisConnectionStringConfig.cs
+++ b/RedisCaching/RedisConnectionStringConfig.cs
@@ -7,9 +7,11 @@ namespace PubComp.Caching.RedisCaching
     {
         public string ConnectionString { get; set; }
 
+        public RedisClientPolicy Policy { get; set; }
+
         public override ICacheConnectionString CreateConnectionString()
         {
-            return new RedisConnectionString(this.Name, this.ConnectionString);
+            return new RedisConnectionString(this.Name, this.ConnectionString, this.Policy);
         }
     }
 }

--- a/SystemRuntime/InMemoryExpirationPolicy.cs
+++ b/SystemRuntime/InMemoryExpirationPolicy.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace PubComp.Caching.SystemRuntime
+{
+    public class InMemoryExpirationPolicy
+    {
+        /// <summary>
+        /// Gets or sets a value that indicates whether a cache entry should be evicted at a specified time.
+        /// </summary>
+        /// <remarks>Default value is a date-time value that is set to the maximum possible value,
+        /// which indicates that the entry does not expire at a pre-specified time</remarks>
+        public DateTimeOffset? AbsoluteExpiration { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that indicates whether a cache entry should be evicted
+        /// within a given span of time since its addition.
+        /// </summary>
+        /// <remarks>Default value is a time-duration value that is set to zero,
+        /// which indicates that a cache entry has no expiration from base on a time span from addition.</remarks>
+        public TimeSpan? ExpirationFromAdd { get; set; }
+
+        /// <summary>
+        /// A span of time within which a cache entry must be accessed
+        /// before the cache entry is evicted from the cache.
+        /// </summary>
+        /// <remarks>Default value is a time-duration value that is set to zero,
+        /// which indicates that a cache entry has no sliding expiration time</remarks>
+        public TimeSpan? SlidingExpiration { get; set; }
+    }
+}

--- a/SystemRuntime/InMemoryPolicy.cs
+++ b/SystemRuntime/InMemoryPolicy.cs
@@ -2,7 +2,7 @@
 
 namespace PubComp.Caching.SystemRuntime
 {
-    public class InMemoryPolicy
+    public class InMemoryPolicy : InMemoryExpirationPolicy
     {
         /// <summary>
         /// Notifications provider name. Default is null/undefined.
@@ -10,27 +10,9 @@ namespace PubComp.Caching.SystemRuntime
         public string SyncProvider { get; set; }
 
         /// <summary>
-        /// Gets or sets a value that indicates whether a cache entry should be evicted at a specified time.
+        /// If set, override expiration policy in case where the sync provider is down
         /// </summary>
-        /// <remarks>Default value is a date-time value that is set to the maximum possible value,
-        /// which indicates that the entry does not expire at a pre-specified time</remarks>
-        public DateTimeOffset? AbsoluteExpiration { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value that indicates whether a cache entry should be evicted
-        /// within a given span of time since its addition.
-        /// </summary>
-        /// <remarks>Default value is a time-duration value that is set to zero,
-        /// which indicates that a cache entry has no expiration from base on a time span from addition.</remarks>
-        public TimeSpan? ExpirationFromAdd { get; set; }
-
-        /// <summary>
-        /// A span of time within which a cache entry must be accessed
-        /// before the cache entry is evicted from the cache.
-        /// </summary>
-        /// <remarks>Default value is a time-duration value that is set to zero,
-        /// which indicates that a cache entry has no sliding expiration time</remarks>
-        public TimeSpan? SlidingExpiration { get; set; }
+        public InMemoryExpirationPolicy OnSyncProviderFailure { get; set; }
 
         /// <summary>
         /// Whether or not to lock on cache misses before calling underlying getter.

--- a/SystemRuntime/InMemorySerializedCache.cs
+++ b/SystemRuntime/InMemorySerializedCache.cs
@@ -52,7 +52,7 @@ namespace PubComp.Caching.SystemRuntime
                     Culture = System.Globalization.CultureInfo.InvariantCulture,
                 });
 
-            InnerCache.Add(key, val, ToRuntimePolicy(Policy), null);
+            InnerCache.Add(key, val, GetRuntimePolicy(), null);
         }
     }
 }

--- a/WebApi/Controllers/ExampleV1Controller.cs
+++ b/WebApi/Controllers/ExampleV1Controller.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using System.Web.Http;
 using PubComp.Caching.Core;
 using TestHost.WebApi.Service;

--- a/WebApi/Service/ExampleService.cs
+++ b/WebApi/Service/ExampleService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using PubComp.Caching.AopCaching;
 

--- a/WebApi/TestHost.WebApi.csproj
+++ b/WebApi/TestHost.WebApi.csproj
@@ -35,8 +35,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>
-    </DocumentationFile>
+    <DocumentationFile>bin\TestHost.WebApi.xml</DocumentationFile>
     <NoWarn>PS0266</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -73,20 +72,42 @@
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.6.8\lib\net45\NLog.dll</HintPath>
+    </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Pipelines.Sockets.Unofficial, Version=1.0.0.0, Culture=neutral, PublicKeyToken=42ea0a778e13fbe2, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pipelines.Sockets.Unofficial.1.0.0\lib\netstandard2.0\Pipelines.Sockets.Unofficial.dll</HintPath>
     </Reference>
     <Reference Include="PostSharp, Version=6.0.28.0, Culture=neutral, PublicKeyToken=b13fd38b8f9c99d7, processorArchitecture=MSIL">
       <HintPath>..\packages\PostSharp.Redist.6.0.28\lib\net45\PostSharp.dll</HintPath>
     </Reference>
+    <Reference Include="StackExchange.Redis, Version=2.0.0.0, Culture=neutral, PublicKeyToken=c219ff1ca8c2ce46, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.2.0.505\lib\net461\StackExchange.Redis.dll</HintPath>
+    </Reference>
     <Reference Include="Swashbuckle.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cd1bb07a5ac7c7bc, processorArchitecture=MSIL">
       <HintPath>..\packages\Swashbuckle.Core.5.6.0\lib\net40\Swashbuckle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Configuration.ConfigurationManager, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Configuration.ConfigurationManager.4.5.0\lib\net461\System.Configuration.ConfigurationManager.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.OracleClient" />
+    <Reference Include="System.Diagnostics.PerformanceCounter, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.PerformanceCounter.4.5.0\lib\net461\System.Diagnostics.PerformanceCounter.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL" />
+    <Reference Include="System.IO.Pipelines, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.4.5.0\lib\netstandard2.0\System.IO.Pipelines.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.0\lib\netstandard2.0\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -99,7 +120,15 @@
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security.AccessControl, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.AccessControl.4.5.0\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
@@ -109,7 +138,14 @@
     <Reference Include="System.Security.Principal.Windows, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.4.5.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Threading.Channels, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Channels.4.5.0\lib\netstandard2.0\System.Threading.Channels.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.0\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web.Cors, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.Cors.5.2.3\lib\net45\System.Web.Cors.dll</HintPath>
@@ -212,6 +248,10 @@
     <ProjectReference Include="..\Core\Core.csproj">
       <Project>{57585B9A-7003-461A-B812-CA48603C839F}</Project>
       <Name>Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\RedisCaching\RedisCaching.csproj">
+      <Project>{222025fc-2d4c-4a4d-b4f9-b874cfe6507f}</Project>
+      <Name>RedisCaching</Name>
     </ProjectReference>
     <ProjectReference Include="..\SystemRuntime\SystemRuntime.csproj">
       <Project>{f9ed87dd-4ac8-48d7-baf0-edb8992ec937}</Project>

--- a/WebApi/Web.config
+++ b/WebApi/Web.config
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   
   <configSections>
     <sectionGroup name="PubComp">
-      <section name="CacheConfig" type="PubComp.Caching.Core.CacheConfigurationHandler, PubComp.Caching.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" allowLocation="true" allowDefinition="Everywhere"/>
+      <section name="CacheConfig" type="PubComp.Caching.Core.CacheConfigurationHandler, PubComp.Caching.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" allowLocation="true" allowDefinition="Everywhere" />
     </sectionGroup>
   <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
 
@@ -12,293 +12,302 @@
   
   <PubComp>
     <CacheConfig>
-      <add name="Numbers" assembly="PubComp.Caching.SystemRuntime" type="PubComp.Caching.SystemRuntime.InMemoryCache" policy="{&quot;ExpirationFromAdd&quot;:&quot;23:59:59&quot;}"/>
+      <add name="localRedis" assembly="PubComp.Caching.RedisCaching" type="RedisConnectionString" connectionString="127.0.0.1:6379,serviceName=mymaster" />
+      <add name="redisNotifier" assembly="PubComp.Caching.RedisCaching" type="RedisCacheNotifier" policy="{'ConnectionName':'localRedis', 'GeneralInvalidationChannel':'+general-invalidation'}" />
+      <add name="redisCache" assembly="PubComp.Caching.RedisCaching" type="RedisCache" policy="{'ConnectionName':'localRedis', 'ExpirationFromAdd':'00:10:00'}" /> 
+
+      <add name="Numbers-m" assembly="PubComp.Caching.SystemRuntime" type="PubComp.Caching.SystemRuntime.InMemoryCache" policy="{'ExpirationFromAdd':'23:59:59', 'SyncProvider':'redisNotifier'}" />
+      <add name="Numbers" assembly="PubComp.Caching.Core" type="LayeredCache" policy="{'Level1CacheName':'Numbers-m', 'Level2CacheName':'redisCache'}" />
     </CacheConfig>
   </PubComp>
 
   <system.web>
-    <compilation debug="true" targetFramework="4.6.1"/>
-    <httpRuntime targetFramework="4.6.1"/>
+    <compilation debug="true" targetFramework="4.6.1" />
+    <httpRuntime targetFramework="4.6.1" />
   </system.web>
   
   <system.webServer>
     <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
-      <remove name="OPTIONSVerbHandler"/>
-      <remove name="TRACEVerbHandler"/>
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
   </system.webServer>
   
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
-				<assemblyIdentity name="System.Reflection.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+				<assemblyIdentity name="System.Reflection.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Threading" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+				<assemblyIdentity name="System.Threading" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Linq.Parallel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+				<assemblyIdentity name="System.Linq.Parallel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Text.Encoding.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+				<assemblyIdentity name="System.Text.Encoding.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Globalization" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+				<assemblyIdentity name="System.Globalization" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Security.SecureString" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+				<assemblyIdentity name="System.Security.SecureString" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
+				<assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Net.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+				<assemblyIdentity name="System.Net.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Reflection" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+				<assemblyIdentity name="System.Reflection" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Net.Sockets" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+				<assemblyIdentity name="System.Net.Sockets" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Collections" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+				<assemblyIdentity name="System.Collections" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Xml.ReaderWriter" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+				<assemblyIdentity name="System.Xml.ReaderWriter" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.IO" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+				<assemblyIdentity name="System.IO" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Diagnostics.Debug" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+				<assemblyIdentity name="System.Diagnostics.Debug" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Resources.ResourceManager" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+				<assemblyIdentity name="System.Resources.ResourceManager" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Runtime" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+				<assemblyIdentity name="System.Runtime" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Linq.Queryable" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+				<assemblyIdentity name="System.Linq.Queryable" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+				<assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Threading.Overlapped" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+				<assemblyIdentity name="System.Threading.Overlapped" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Text.RegularExpressions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+				<assemblyIdentity name="System.Text.RegularExpressions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Threading.Tasks" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+				<assemblyIdentity name="System.Threading.Tasks" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.IO.Compression" publicKeyToken="B77A5C561934E089" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+				<assemblyIdentity name="System.IO.Compression" publicKeyToken="B77A5C561934E089" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Diagnostics.Contracts" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+				<assemblyIdentity name="System.Diagnostics.Contracts" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+				<assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Runtime.Numerics" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+				<assemblyIdentity name="System.Runtime.Numerics" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Text.Encoding" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+				<assemblyIdentity name="System.Text.Encoding" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.ComponentModel.EventBasedAsync" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+				<assemblyIdentity name="System.ComponentModel.EventBasedAsync" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Collections.Concurrent" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+				<assemblyIdentity name="System.Collections.Concurrent" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+				<assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Dynamic.Runtime" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+				<assemblyIdentity name="System.Dynamic.Runtime" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Reflection.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+				<assemblyIdentity name="System.Reflection.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Security.Principal" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+				<assemblyIdentity name="System.Security.Principal" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.ComponentModel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+				<assemblyIdentity name="System.ComponentModel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Linq" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+				<assemblyIdentity name="System.Linq" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Security.Cryptography.Algorithms" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+				<assemblyIdentity name="System.Security.Cryptography.Algorithms" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Threading.Timer" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+				<assemblyIdentity name="System.Threading.Timer" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Diagnostics.StackTrace" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+				<assemblyIdentity name="System.Diagnostics.StackTrace" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Xml.XmlSerializer" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+				<assemblyIdentity name="System.Xml.XmlSerializer" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Net.Http" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+				<assemblyIdentity name="System.Net.Http" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Globalization.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+				<assemblyIdentity name="System.Globalization.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Net.NetworkInformation" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+				<assemblyIdentity name="System.Net.NetworkInformation" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Xml.XDocument" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+				<assemblyIdentity name="System.Xml.XDocument" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Runtime.Serialization.Json" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+				<assemblyIdentity name="System.Runtime.Serialization.Json" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.ObjectModel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+				<assemblyIdentity name="System.ObjectModel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+				<assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Linq.Expressions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+				<assemblyIdentity name="System.Linq.Expressions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Threading.Tasks.Parallel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+				<assemblyIdentity name="System.Threading.Tasks.Parallel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Runtime.Serialization.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+				<assemblyIdentity name="System.Runtime.Serialization.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
+				<assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Diagnostics.Tools" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+				<assemblyIdentity name="System.Diagnostics.Tools" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Net.Requests" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+				<assemblyIdentity name="System.Net.Requests" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Data.Common" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+				<assemblyIdentity name="System.Data.Common" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Runtime.Serialization.Xml" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.1.3.0" newVersion="4.1.3.0"/>
+				<assemblyIdentity name="System.Runtime.Serialization.Xml" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.1.3.0" newVersion="4.1.3.0" />
 			</dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
+        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="PostSharp" publicKeyToken="b13fd38b8f9c99d7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.0.44.0" newVersion="5.0.44.0"/>
+        <assemblyIdentity name="PostSharp" publicKeyToken="b13fd38b8f9c99d7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.44.0" newVersion="5.0.44.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Practices.Unity" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0"/>
+        <assemblyIdentity name="Microsoft.Practices.Unity" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Unity.Abstractions" publicKeyToken="6d32ff45e0ccc69f" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.2.0" newVersion="3.1.2.0"/>
+        <assemblyIdentity name="Unity.Abstractions" publicKeyToken="6d32ff45e0ccc69f" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.2.0" newVersion="3.1.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Unity.Container" publicKeyToken="489b6accfaf20ef0" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.5.5.0" newVersion="5.5.5.0"/>
+        <assemblyIdentity name="Unity.Container" publicKeyToken="489b6accfaf20ef0" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.5.5.0" newVersion="5.5.5.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0"/>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
 
   <system.codedom>
     <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701"/>
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"/>
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
     </compilers>
   </system.codedom>
 

--- a/WebApi/packages.config
+++ b/WebApi/packages.config
@@ -22,15 +22,26 @@
   <package id="Microsoft.Owin.Host.SystemWeb" version="3.1.0" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
+  <package id="NLog" version="4.6.8" targetFramework="net461" />
   <package id="Owin" version="1.0" targetFramework="net461" />
+  <package id="Pipelines.Sockets.Unofficial" version="1.0.0" targetFramework="net461" />
   <package id="PostSharp" version="6.0.28" targetFramework="net461" developmentDependency="true" />
   <package id="PostSharp.Redist" version="6.0.28" targetFramework="net461" />
+  <package id="StackExchange.Redis" version="2.0.505" targetFramework="net461" />
   <package id="Swashbuckle.Core" version="5.6.0" targetFramework="net462" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net461" />
   <package id="System.Configuration.ConfigurationManager" version="4.5.0" targetFramework="net461" />
+  <package id="System.Diagnostics.PerformanceCounter" version="4.5.0" targetFramework="net461" />
+  <package id="System.IO.Pipelines" version="4.5.0" targetFramework="net461" />
+  <package id="System.Memory" version="4.5.0" targetFramework="net461" />
+  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net461" />
   <package id="System.Runtime.Caching" version="4.5.0" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net461" />
   <package id="System.Security.AccessControl" version="4.5.0" targetFramework="net461" />
   <package id="System.Security.Permissions" version="4.5.0" targetFramework="net461" />
   <package id="System.Security.Principal.Windows" version="4.5.0" targetFramework="net461" />
+  <package id="System.Threading.Channels" version="4.5.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.0" targetFramework="net461" />
   <package id="Unity" version="5.5.5" targetFramework="net461" />
   <package id="Unity.Abstractions" version="3.1.2" targetFramework="net461" />
   <package id="Unity.AspNet.WebApi" version="5.0.11" targetFramework="net461" />


### PR DESCRIPTION
**RedisNotifier**

- new policy option: GeneralInvalidationChannel to support invalidation requests by external orchestrator
- new policy option: InvalidateOnUpdate to support automatic publication of CacheItemActionTypes.Updated when updating existing cache item

**InMemory**

-  new policy option: OnSyncProviderFailure to enable
1. Fallback expiry policy
2. Automatic Invalidation on connection state change

**RedisClient** - bug fix

- Reuse multiplex connections by name instead of creating new connections per cache manager
