### PR TITLE
dispose of previous inner (in-memory) cache when calling ClearAll()

### DIFF
--- a/Core.UnitTests/CacheInterfaceTests.cs
+++ b/Core.UnitTests/CacheInterfaceTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PubComp.Caching.Core.UnitTests
@@ -212,6 +213,42 @@ namespace PubComp.Caching.Core.UnitTests
             result = cache.Get("key", getter);
             Assert.AreNotEqual(1, misses);
             Assert.AreNotEqual("1", result);
+        }
+
+        [TestMethod]
+        [Ignore("Diagnose manually the memory consumption")]
+        public void LotsOfClearAll()
+        {
+            var cache = GetCache("cache1");
+            for (var i = 0; i < 5000; i++)
+            {
+                cache.ClearAll();
+            }
+            Thread.Sleep(1000);
+            GC.Collect();
+            Thread.Sleep(1000);
+            for (var i = 0; i < 5000; i++)
+            {
+                cache.ClearAll();
+            }
+        }
+
+        [TestMethod]
+        [Ignore("Diagnose manually the memory consumption")]
+        public async Task LotsOfClearAsyncAll()
+        {
+            var cache = GetCache("cache1");
+            for (var i = 0; i < 5000; i++)
+            {
+                await cache.ClearAllAsync().ConfigureAwait(false);
+            }
+            await Task.Delay(1000);
+            GC.Collect();
+            await Task.Delay(1000);
+            for (var i = 0; i < 5000; i++)
+            {
+                await cache.ClearAllAsync().ConfigureAwait(false);
+            }
         }
 
         [TestMethod]

--- a/SystemRuntime.UnitTests/InMemoryCacheTests.cs
+++ b/SystemRuntime.UnitTests/InMemoryCacheTests.cs
@@ -110,6 +110,7 @@ namespace PubComp.Caching.SystemRuntime.UnitTests
         }
 
         [TestMethod]
+        [Ignore("only a one time test needed")]
         public void LoadTest_LockingStrategiesComparison()
         {
             const int numberOfThreads = 16;

--- a/SystemRuntime/SystemRuntime.csproj
+++ b/SystemRuntime/SystemRuntime.csproj
@@ -5,9 +5,9 @@
     <AssemblyName>PubComp.Caching.SystemRuntime</AssemblyName>
     <RootNamespace>PubComp.Caching.SystemRuntime</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>5.0.0</Version>
+    <Version>5.0.1</Version>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
-    <FileVersion>5.0.0.0</FileVersion>
+    <FileVersion>5.0.1.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;1591</NoWarn>


### PR DESCRIPTION
This fixes a memory leak happens upon calling ClearAll() on InMemoryCache instances.

I had a concern that some classes will hold the reference of the previous cache and that the disposing will cause in certain edge race cases a serious exception (AlreadyDisposedException).
But using the dispose cache object is ok, but does nothing and no exception as well.
Set: will not set, as if the ClearAll was called a nanosecond after setting
Get: will get nothing, as if the ClearAll was called a nanosecond before getting