### PR TITLE
reverting changes done in CacheAttribute and CacheListAttribute.

### DIFF
--- a/AopCaching/AopCaching.csproj
+++ b/AopCaching/AopCaching.csproj
@@ -5,9 +5,9 @@
     <AssemblyName>PubComp.Caching.AopCaching</AssemblyName>
     <RootNamespace>PubComp.Caching.AopCaching</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>5.0.4</Version>
+    <Version>5.0.5</Version>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
-    <FileVersion>5.0.4.0</FileVersion>
+    <FileVersion>5.0.5.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;1591</NoWarn>

--- a/AopCaching/CacheAttribute.cs
+++ b/AopCaching/CacheAttribute.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace PubComp.Caching.AopCaching
 {
-    [PSerializable]
+    [Serializable]
     public class CacheAttribute : MethodInterceptionAspect
     {
         private string cacheName;

--- a/AopCaching/CacheListAttribute.cs
+++ b/AopCaching/CacheListAttribute.cs
@@ -12,7 +12,7 @@ using PostSharp.Serialization;
 
 namespace PubComp.Caching.AopCaching
 {
-    [PSerializable]
+    [Serializable]
     public class CacheListAttribute : MethodInterceptionAspect
     {
         private string cacheName;


### PR DESCRIPTION
in versions 5.0.3 + 5.0.4  - [Serializable] was changed to [PSerializable]. those chanes to be considerd as breaking changes.
please do not use versions 5.0.3 and 5.0.4.
if you do want the to use the [PSerializable]. please upgrade to version > 6.0.0